### PR TITLE
FIX: la validación de puertos ya no cuenta el propio proyecto ni los contenedores detenidos

### DIFF
--- a/rocketdoo/core/port_validation.py
+++ b/rocketdoo/core/port_validation.py
@@ -1,4 +1,5 @@
 # rocketdoo/core/port_validation.py
+import re
 import socket
 import subprocess
 import platform
@@ -72,95 +73,233 @@ def _check_port_unix(port: int) -> bool:
     return False
 
 
-def _check_port_in_docker_files(port: int) -> tuple[bool, str]:
+# Directorios que nunca contienen proyectos rocketdoo y encarecen el barrido
+_PRUNED_DIRS = {
+    'node_modules', '__pycache__', 'venv', 'site-packages', 'dist', 'build',
+    'filestore', 'sessions', 'external_addons', 'enterprise', 'postgresql',
+}
+
+# Nombres de archivo de compose reconocidos
+_COMPOSE_NAMES = ('docker-compose.yaml', 'docker-compose.yml', 'compose.yaml', 'compose.yml')
+
+# Niveles máximos a descender desde cada raíz de búsqueda
+_MAX_SCAN_DEPTH = 3
+
+
+def _host_port(port_mapping) -> int | None:
     """
-    Busca el puerto en archivos docker-compose.yaml en directorios hermanos/padres.
-    Retorna (está_en_uso, proyecto_encontrado)
+    Extrae el puerto del host de una entrada de 'ports' de docker-compose.
+
+    Soporta "8069:8069", "8069:8069/tcp", "127.0.0.1:8069:8069", el entero 8069
+    y la forma larga {'published': 8069, 'target': 8069}. Devuelve None cuando la
+    entrada no reserva un puerto del host (p. ej. "8069" a secas, que publica en
+    un puerto aleatorio) o cuando no es un número (p. ej. "${ODOO_PORT}:8069").
     """
-    # Buscar en directorios hermanos y padres
-    search_paths = [
-        Path.home() / "rocketdoo",  # En home
-        Path.cwd().parent,           # Directorio padre
-        Path.cwd().parent.parent,    # Abuelo
-    ]
-    
-    for search_path in search_paths:
-        if not search_path.exists():
+    if isinstance(port_mapping, bool):
+        return None
+    if isinstance(port_mapping, int):
+        return port_mapping
+    if isinstance(port_mapping, dict):
+        try:
+            return int(port_mapping.get('published'))
+        except (TypeError, ValueError):
+            return None
+    if not isinstance(port_mapping, str):
+        return None
+
+    parts = port_mapping.split(':')
+    if len(parts) < 2:
+        # Sólo puerto del contenedor: Docker asigna un puerto de host aleatorio
+        return None
+    try:
+        return int(parts[-2].split('/')[0].strip())
+    except ValueError:
+        return None
+
+
+def _iter_compose_files(exclude_dir=None, max_depth: int = _MAX_SCAN_DEPTH):
+    """
+    Recorre los archivos de compose de proyectos hermanos/padres.
+
+    Excluye el proyecto actual (o 'exclude_dir'), poda directorios ocultos y
+    pesados, limita la profundidad y no devuelve el mismo archivo dos veces
+    aunque las raíces de búsqueda se solapen.
+    """
+    cwd = Path.cwd().resolve()
+    try:
+        excluded = Path(exclude_dir).resolve() if exclude_dir else cwd
+    except OSError:
+        excluded = cwd
+
+    roots = []
+    for candidate in (Path.home() / "rocketdoo", cwd.parent, cwd.parent.parent):
+        try:
+            candidate = candidate.resolve()
+        except OSError:
             continue
-            
-        for docker_file in search_path.rglob("docker-compose.yaml"):
-            try:
-                with open(docker_file, 'r', encoding='utf-8') as f:
-                    content = yaml.safe_load(f)
-                    if not content or 'services' not in content:
-                        continue
-                    
-                    for service_name, service_config in content.get('services', {}).items():
-                        if 'ports' not in service_config:
-                            continue
-                        
-                        ports = service_config['ports']
-                        if isinstance(ports, list):
-                            for port_mapping in ports:
-                                # Parsear "8069:8069" o "8069:8069/tcp"
-                                if isinstance(port_mapping, str):
-                                    host_port = port_mapping.split(':')[0].split('/')[0]
-                                    try:
-                                        if int(host_port) == port:
-                                            project_name = docker_file.parent.name
-                                            return True, project_name
-                                    except ValueError:
-                                        pass
-            except Exception as e:
-                # Ignorar archivos que no se puedan leer
-                pass
-    
-    return False, ""
+        if candidate.is_dir() and candidate not in roots:
+            roots.append(candidate)
+
+    seen = set()
+    for root in roots:
+        root_depth = len(root.parts)
+        for dirpath, dirnames, filenames in os.walk(root, topdown=True):
+            current = Path(dirpath)
+
+            # No volver a entrar al proyecto actual: sus puertos son propios,
+            # no un conflicto (esto es lo que hacía que 'rkd init' no fuera
+            # re-ejecutable).
+            if current == excluded or excluded in current.parents:
+                dirnames[:] = []
+                continue
+
+            if len(current.parts) - root_depth >= max_depth:
+                dirnames[:] = []
+            else:
+                dirnames[:] = [
+                    d for d in dirnames
+                    if not d.startswith('.') and d not in _PRUNED_DIRS
+                ]
+
+            for name in _COMPOSE_NAMES:
+                if name not in filenames:
+                    continue
+                try:
+                    compose_file = (current / name).resolve()
+                except OSError:
+                    continue
+                if compose_file not in seen:
+                    seen.add(compose_file)
+                    yield compose_file
 
 
-def is_port_used_by_rocketdoo(port: int) -> bool:
-    """Detecta si un puerto está siendo usado por un contenedor Rocketdoo."""
+def collect_declared_ports(exclude_dir=None) -> dict[int, str]:
+    """
+    Devuelve {puerto_host: nombre_de_proyecto} leyendo cada compose una sola vez.
+
+    Un puerto declarado acá NO significa que esté ocupado: puede pertenecer a un
+    proyecto detenido. Sirve para advertir y para sugerir puertos sin colisión
+    futura.
+    """
+    declared: dict[int, str] = {}
+    for compose_file in _iter_compose_files(exclude_dir):
+        try:
+            with open(compose_file, 'r', encoding='utf-8') as f:
+                content = yaml.safe_load(f)
+        except Exception:
+            # Compose ilegible o YAML inválido: no es asunto nuestro
+            continue
+
+        if not isinstance(content, dict):
+            continue
+        services = content.get('services')
+        if not isinstance(services, dict):
+            continue
+
+        project_name = compose_file.parent.name
+        for service_config in services.values():
+            if not isinstance(service_config, dict):
+                continue
+            ports = service_config.get('ports')
+            if not isinstance(ports, list):
+                continue
+            for port_mapping in ports:
+                host_port = _host_port(port_mapping)
+                if host_port is not None:
+                    declared.setdefault(host_port, project_name)
+    return declared
+
+
+def _check_port_in_docker_files(port: int, exclude_dir=None) -> tuple[bool, str]:
+    """
+    Compatibilidad: (está_declarado, proyecto) para un puerto puntual.
+
+    Excluye el proyecto actual. Preferir collect_declared_ports() cuando haya que
+    consultar varios puertos.
+    """
+    project_name = collect_declared_ports(exclude_dir).get(int(port), "")
+    return bool(project_name), project_name
+
+
+def get_port_reservation(port: int, exclude_dir=None) -> str | None:
+    """
+    Advertencia (no error) si otro proyecto declara el puerto en su compose.
+
+    El puerto está libre ahora — el proyecto que lo declara está detenido —, pero
+    habrá conflicto si se levantan los dos a la vez.
+    """
+    declared, project_name = _check_port_in_docker_files(port, exclude_dir)
+    if not declared:
+        return None
+    return (
+        f"Port {port} is also declared by project '{project_name}' (not running now). "
+        f"Both projects cannot run at the same time on this port."
+    )
+
+
+def get_port_publisher(port: int) -> str | None:
+    """Nombre del contenedor Docker que publica el puerto, o None."""
     try:
         output = subprocess.check_output(
-            ['docker', 'ps', '--format', '{{.Names}} {{.Ports}}'],
+            ['docker', 'ps', '--format', '{{.Names}}\t{{.Ports}}'],
             stderr=subprocess.DEVNULL,
             text=True
         )
-        for line in output.splitlines():
-            if 'rocketdoo' in line.lower() and str(port) in line:
-                return True
     except (subprocess.CalledProcessError, FileNotFoundError):
-        return False
-    return False
+        return None
+
+    # El puerto del host aparece antes de '->': "0.0.0.0:8069->8069/tcp".
+    # El límite de dígitos evita que 8069 matchee 18069.
+    pattern = re.compile(rf'(?<![0-9]){port}->')
+    for line in output.splitlines():
+        name, _, ports = line.partition('\t')
+        if pattern.search(ports):
+            return name
+    return None
 
 
-def find_available_port(start=1024, end=65535):
-    """Busca un puerto disponible comenzando desde 'start'."""
-    for p in range(start, end):
-        if not is_port_in_use(p) and not _check_port_in_docker_files(p)[0]:
+def is_port_used_by_rocketdoo(port: int) -> bool:
+    """Compatibilidad: True si algún contenedor Docker está publicando el puerto."""
+    return get_port_publisher(port) is not None
+
+
+def find_available_port(start=1024, end=65535, exclude_dir=None, declared=None):
+    """
+    Primer puerto libre desde 'start', evitando los declarados por otros proyectos.
+
+    'declared' permite reutilizar el resultado de collect_declared_ports() y no
+    releer los compose por cada puerto candidato.
+    """
+    if declared is None:
+        declared = collect_declared_ports(exclude_dir)
+
+    for p in range(max(int(start), 1024), int(end)):
+        if p in declared:
+            continue
+        if not is_port_in_use(p):
             return p
     raise RuntimeError("No available ports found")
 
 
 def validate_port(port, label="port"):
-    """Valida si un puerto está disponible."""
+    """
+    Valida un puerto y lo devuelve normalizado.
+
+    Sólo falla si el puerto está realmente ocupado. Un puerto declarado en el
+    compose de otro proyecto detenido no es un error: ver get_port_reservation().
+    """
     try:
         port = int(str(port).strip())
     except Exception:
         raise ValueError(f"Invalid {label} ({port})")
-    
+
     if port < 1024 or port > 65535:
         raise ValueError(f"{label} must be between 1024 and 65535")
-    
-    # Verificar si está en uso actualmente
+
     if is_port_in_use(port):
-        if is_port_used_by_rocketdoo(port):
-            raise RuntimeError(f"Port {port} is used by another Rocketdoo project")
+        container = get_port_publisher(port)
+        if container:
+            raise RuntimeError(f"Port {port} is already published by container '{container}'")
         raise RuntimeError(f"Port {port} is in use by another application")
-    
-    # Verificar si está reservado en otros docker-compose.yaml
-    port_in_docker_file, project_name = _check_port_in_docker_files(port)
-    if port_in_docker_file:
-        raise RuntimeError(f"Port {port} is reserved in project '{project_name}'")
-    
+
     return port

--- a/rocketdoo/init_project.py
+++ b/rocketdoo/init_project.py
@@ -5,7 +5,12 @@ from pathlib import Path
 from jinja2 import Environment, FileSystemLoader
 import questionary
 from rocketdoo.welcome import show_welcome
-from rocketdoo.core.port_validation import validate_port, find_available_port
+from rocketdoo.core.port_validation import (
+    validate_port,
+    find_available_port,
+    get_port_reservation,
+    collect_declared_ports,
+)
 from rocketdoo.core.edition_setup import setup_enterprise_edition
 from rocketdoo.core.ssh_manager import (
     list_private_keys,
@@ -60,19 +65,31 @@ def prompt_port(label, default_port):
 
 
 def validate_ports(odoo_port, vsc_port):
-    """Validate both ports and return True if both are free"""
+    """Validate both ports and return True if both can be used.
+
+    A port declared in another project's docker-compose is only a warning: that
+    project is not running, so the port is free right now.
+    """
     errors = []
-    try:
-        validate_port(odoo_port, "Odoo Port")
-    except RuntimeError as e:
-        errors.append(str(e))
-    try:
-        validate_port(vsc_port, "VSC Debug Port")
-    except RuntimeError as e:
-        errors.append(str(e))
+    warnings = []
+
+    for value, label in ((odoo_port, "Odoo Port"), (vsc_port, "VSC Debug Port")):
+        try:
+            validate_port(value, label)
+        except RuntimeError as e:
+            errors.append(str(e))
+            continue
+        reservation = get_port_reservation(value)
+        if reservation:
+            warnings.append(reservation)
+
+    if warnings:
+        click.echo("\n⚠️  Heads up:")
+        for warning in warnings:
+            click.echo(f"  • {warning}")
 
     if errors:
-        click.echo("\n⚠️  The following issues were found:")
+        click.echo("\n❌ The following ports are not available:")
         for error in errors:
             click.echo(f"  • {error}")
         return False
@@ -93,8 +110,10 @@ def prompt_ports_until_valid(default_odoo=8069, default_vsc=8888):
 
         # If there are errors, offer suggestions
         click.echo("\n💡 Suggested available ports:")
-        suggested_odoo = find_available_port(odoo_port + 1)
-        suggested_vsc = find_available_port(vsc_port + 1)
+        # Un solo barrido de los compose vecinos para ambas sugerencias
+        declared = collect_declared_ports()
+        suggested_odoo = find_available_port(odoo_port + 1, declared=declared)
+        suggested_vsc = find_available_port(vsc_port + 1, declared=declared)
         click.echo(f"  • Odoo: {suggested_odoo}")
         click.echo(f"  • VSC:  {suggested_vsc}")
 


### PR DESCRIPTION
## Qué cambia

La validación de puertos deja de inventar conflictos:

- **Excluye el proyecto actual** del barrido de `docker-compose`. Era la causa de que `rkd init` no fuera re-ejecutable: el `rglob` sobre el directorio padre volvía a entrar en el propio proyecto y declaraba sus puertos como reservados.
- **Un puerto declarado por otro proyecto detenido ya no es error**, es advertencia (`get_port_reservation`). Sólo falla el puerto realmente ocupado, y en ese caso el mensaje nombra el contenedor que lo publica (`get_port_publisher`).
- **Un solo barrido, con poda.** `collect_declared_ports()` lee cada compose una vez, saltea directorios ocultos y pesados (`node_modules`, `venv`, `filestore`, `external_addons`, …) y limita la profundidad. Antes `find_available_port()` releía *todos* los compose por cada puerto candidato.
- **Más formatos reconocidos:** `docker-compose.yml`, `compose.yaml`, `compose.yml`, mappings `127.0.0.1:8069:8069`, forma larga `{published: …}`; y `"8069"` a secas ya no se cuenta como reserva de puerto de host (Docker asigna uno aleatorio).
- **`8069` ya no matchea `18069`** al leer la salida de `docker ps`.
- El wizard separa errores de advertencias y reutiliza un único barrido para las dos sugerencias.

Refs #124

## Compatibilidad

`validate_port()`, `is_port_in_use()`, `is_port_used_by_rocketdoo()`, `find_available_port()` y `_check_port_in_docker_files()` conservan su firma; los consumidores (`init_project.py`, `unpack_environment.py`, `gui/api/setup.py`) no necesitan cambios más allá del wizard.

## Cómo probarlo

Verificado en el workspace real donde se reportó el bug (12 proyectos, todos los contenedores en `Exited`), desde `HDMSOFT/ODOO/odoo16-mig-session`:

```
barrido: 0.05s · 14 puertos declarados por otros proyectos
propios puertos en el mapa (deben ser False): False False
  8270: OK   warning=None
  8485: OK   warning=None
  8069: OK   warning=Port 8069 is also declared by project 'loan-management-pro_DEV' (not running now). …
  8888: OK   warning=Port 8888 is also declared by project 'loan-management-pro_DEV' (not running now). …
```

Antes: `Port 8270 is reserved in project 'odoo16-mig-session'` (su propio proyecto) y `Port 8069 is reserved in project 'loan-management-pro_DEV'` con todo apagado.

Reproducción sintética con workspace de 3 proyectos: 21 checks (atribución de puertos, exclusión del propio proyecto, advertencia vs error, sugerencias, regex de `docker ps`, parseo de mappings) — todos en verde.

## Verificado

- [x] Los 5 criterios de aceptación de #124
- [x] `flake8 rocketdoo --select=E9,F63,F7,F82` limpio
- [x] `python -c "import rocketdoo, rocketdoo.cli"` OK
- [x] No se modificó `pyproject.toml` (el bump va aparte)
