### PR TITLE
FIX: rkd info ya no reporta claves SSH desde líneas comentadas del Dockerfile

### DIFF
--- a/rocketdoo/project_info.py
+++ b/rocketdoo/project_info.py
@@ -87,17 +87,32 @@ def extract_odoo_version_from_dockerfile() -> Optional[str]:
 
 
 def detect_ssh_key_usage() -> Optional[str]:
-    """Detects if an SSH key is being used in Dockerfile"""
+    """Detects if an SSH key is being used in Dockerfile.
+
+    Sólo cuentan las instrucciones activas: la plantilla deja el bloque SSH
+    comentado, y un '#COPY ./.ssh/rsa /root/.ssh/id_rsa' se reportaba como clave
+    en uso porque la comparación era por substring sobre la línea completa.
+    """
     dockerfile = read_dockerfile()
-    if dockerfile:
-        # Search for lines mentioning SSH keys
-        for line in dockerfile.split('\n'):
-            if 'COPY' in line and ('.ssh' in line or 'id_' in line):
-                # Extract file name
-                parts = line.split()
-                if len(parts) >= 3:
-                    ssh_file = parts[1]
-                    return os.path.basename(ssh_file)
+    if not dockerfile:
+        return None
+
+    for raw_line in dockerfile.split('\n'):
+        line = raw_line.strip()
+        if not line or line.startswith('#'):
+            continue
+
+        parts = line.split()
+        # COPY tiene que ser la instrucción, no aparecer en cualquier parte
+        if len(parts) < 3 or parts[0].upper() != 'COPY':
+            continue
+
+        source, dest = parts[1], parts[2]
+        if ('.ssh' in source or '.ssh' in dest
+                or 'id_' in os.path.basename(source)
+                or 'id_' in os.path.basename(dest)):
+            return os.path.basename(source)
+
     return None
 
 
@@ -109,13 +124,10 @@ def detect_enterprise_edition() -> bool:
         if web_service:
             volumes = web_service.get('volumes', [])
             for volume in volumes:
-                if isinstance(volume, str):
-                    # Check if enterprise volume exists and is NOT commented
-                    volume_stripped = volume.strip()
-                    if 'enterprise' in volume_stripped.lower():
-                        # If line doesn't start with #, it's uncommented (Enterprise)
-                        if not volume_stripped.startswith('#'):
-                            return True
+                # yaml.safe_load ya descartó los volúmenes comentados: todo lo
+                # que llega acá es una línea activa del compose
+                if isinstance(volume, str) and 'enterprise' in volume.lower():
+                    return True
     
     # Also check in Dockerfile for enterprise references
     dockerfile = read_dockerfile()


### PR DESCRIPTION
## Qué cambia

`detect_ssh_key_usage()` sólo mira instrucciones **activas** del Dockerfile:

- se descartan las líneas comentadas
- `COPY` tiene que ser la instrucción (`parts[0]`), no aparecer en cualquier parte de la línea
- la búsqueda de `.ssh` / `id_` se hace sobre **origen y destino** del `COPY`, para no perder casos que la versión anterior sí detectaba (p. ej. `COPY mykey /root/.ssh/id_rsa`)

Y se limpia la rama muerta de `detect_enterprise_edition()`: los volúmenes llegan de `yaml.safe_load()`, que ya descartó los comentados, así que `volume_stripped.startswith('#')` no podía dispararse nunca. El chequeo de comentarios sobre el **Dockerfile** se mantiene, ahí sí es texto crudo.

Refs #128

## Por qué

El bloque SSH de la plantilla queda comentado cuando el wizard se responde con *No*, y `#COPY ./.ssh/rsa /root/.ssh/id_rsa` matcheaba igual: `parts[1]` caía en la ruta de la clave y `basename()` devolvía `rsa`. Resultado: `rkd info` afirmaba `Private Repositories ✅ (key: rsa)` en proyectos sin ninguna clave, y el error se propagaba a `use_private_repos` en `get_project_info()` y al endpoint `GET /api/project` de la GUI.

## Cómo probarlo

```bash
mkdir /tmp/rkd-ssh-check && cd /tmp/rkd-ssh-check
rkd scaffold && rkd init     # responder No en repos privados
rkd info                     # → 🔐 Private Repositories ❌
```

Salida real de los dos casos con este cambio:

```
sin-ssh:  🔐 Private Repositories   ❌
con-ssh:  🔐 Private Repositories   ✅ (key: windows-local)
```

El proyecto `con-ssh` se generó con `inject_ssh_into_dockerfile()`, el mismo código que usa el wizard, así que la línea probada es la real: `COPY ./.ssh/windows-local /root/.ssh/windows-local`.

## Verificado

- [x] Proyecto sin SSH → `detect_ssh_key_usage()` = `None`, `use_private_repos` falso, `ssh_key` vacío
- [x] Proyecto con SSH → devuelve `windows-local` y `use_private_repos = True`
- [x] Los otros `COPY` del Dockerfile (`odoo.conf`, `install_dependencies.sh`) no se confunden con claves
- [x] Enterprise: volumen activo → `True`, volumen comentado → `False` (sin regresión)
- [x] `flake8 rocketdoo --select=E9,F63,F7,F82` limpio
- [x] `pyproject.toml` sin tocar: el bump a 3.1.6 va al cortar el release en `dev/v3`
