### PR TITLE
FIX: genera .gitignore en el scaffold para no commitear secretos

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,6 @@
 include README.md
 include LICENSE
+include rocketdoo/templates/.gitignore.jinja
 include rocketdoo/templates/deploy/.deployignore
 include rocketdoo/templates/deploy/deploy.yaml.jinja
 recursive-include rocketdoo/templates *

--- a/README.md
+++ b/README.md
@@ -473,6 +473,31 @@ Additional interface features:
 
 ---
 
+### Keeping secrets out of git
+
+A Rocketdoo project keeps credentials on disk: the SSH private key copied into
+the build context, the PostgreSQL secret, and the Odoo master password written
+into config files. `rkd scaffold` and `rkd init` therefore always write a
+`.gitignore` covering them:
+
+| Path | Why it must not be committed |
+|------|------------------------------|
+| `.ssh/` | SSH private key copied into the Docker build context |
+| `.rkd/secrets/` | VPS passwords for `rkd deploy` and `rkd instance` |
+| `odoo_pg_pass` | PostgreSQL password (Docker secret) |
+| `.rkd/instance.yaml` | Deployment config, holds `admin_passwd` in clear text |
+| `config/odoo.conf` | Odoo config, holds `admin_passwd` in clear text |
+
+An existing `.gitignore` is never overwritten — your own rules are kept and only
+the missing entries are appended. `rkd info` warns when a project is missing
+coverage; run `rkd scaffold` in it to fix it.
+
+> `config/odoo.conf` is ignored because `rkd init` regenerates it and it carries
+> the master password. If your team needs to version it, commit a sanitized copy
+> as `config/odoo.conf.example`.
+
+---
+
 ### Technical Support
 
 - If you have any questions or issues with our development environment, you can contact us and submit your inquiry or support ticket by clicking on the link below.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ include = ["rocketdoo*"]
 # 🚀 Include templates in the package
 [tool.setuptools.package-data]
 rocketdoo = [
+    "templates/.gitignore.jinja",
     "templates/**/*",
     "templates/**/**/*",
     "templates/**/.vscode/*",

--- a/rocketdoo/cli.py
+++ b/rocketdoo/cli.py
@@ -9,6 +9,7 @@ from rich import box
 from .scaffold import scaffold_project
 from .init_project import init_project
 from .project_info import get_project_info, project_exists
+from rocketdoo.core.gitignore_manager import missing_entries
 from rocketdoo import __version__
 import questionary
 from rocketdoo.docker_cli import docker, up, down, status, stop, pause, logs, build, restart
@@ -396,6 +397,21 @@ def info():
             padding=(1, 1)
         ))
     
+    # Warn if secrets in this project could be committed
+    missing = missing_entries(Path.cwd())
+    if missing:
+        warn = Text()
+        warn.append("⚠️  These files hold credentials and are not ignored by git:\n\n", style="bold yellow")
+        for pattern, why in missing:
+            warn.append(f"   {pattern}", style="bold")
+            warn.append(f" — {why}\n", style="dim")
+        warn.append("\n💡 Fix it with: ", style="dim")
+        warn.append("rkd scaffold", style="bold cyan")
+        warn.append(" (keeps your existing rules)", style="dim")
+        console.print()
+        console.print(Panel(warn, title="[bold yellow]Secrets at risk[/bold yellow]",
+                            border_style="yellow", box=box.ROUNDED, padding=(1, 1)))
+
     # Footer with framework information
     console.print()
     footer_text = Text()

--- a/rocketdoo/core/gitignore_manager.py
+++ b/rocketdoo/core/gitignore_manager.py
@@ -1,0 +1,86 @@
+"""
+RocketDoo - .gitignore management for generated projects.
+
+A Rocketdoo project holds credentials on disk (the SSH build context, the
+PostgreSQL secret, admin passwords inside config files). Without a .gitignore
+a plain `git add .` commits all of them, so scaffold/init always write one and
+`rkd info` warns when an existing project is missing coverage.
+
+The template lives at templates/.gitignore.jinja — named with the .jinja
+suffix so git does not apply it to Rocketdoo's own source tree.
+"""
+from pathlib import Path
+
+_TEMPLATE = Path(__file__).parent.parent / 'templates' / '.gitignore.jinja'
+
+# Entries that must be present for credentials to stay out of the repo.
+# Kept deliberately short: these are the leak vectors, not the full template.
+SENSITIVE_ENTRIES = [
+    ('.ssh/', 'SSH private key copied into the build context'),
+    ('.rkd/secrets/', 'VPS passwords'),
+    ('odoo_pg_pass', 'PostgreSQL password'),
+    ('.rkd/instance.yaml', 'deployment config with admin_passwd'),
+    ('config/odoo.conf', 'Odoo config with admin_passwd'),
+]
+
+
+def template_content() -> str:
+    """Return the canonical .gitignore shipped with Rocketdoo."""
+    return _TEMPLATE.read_text()
+
+
+def _entries(text: str) -> set[str]:
+    """Non-comment, non-empty lines of a .gitignore."""
+    return {
+        line.strip()
+        for line in text.splitlines()
+        if line.strip() and not line.lstrip().startswith('#')
+    }
+
+
+def missing_entries(project_root: Path) -> list[tuple[str, str]]:
+    """
+    Return the sensitive entries a project's .gitignore does not cover.
+
+    A missing .gitignore returns every entry.
+    """
+    gitignore = Path(project_root) / '.gitignore'
+    if not gitignore.exists():
+        return list(SENSITIVE_ENTRIES)
+
+    present = _entries(gitignore.read_text())
+    return [(pat, why) for pat, why in SENSITIVE_ENTRIES if pat not in present]
+
+
+def ensure_gitignore(project_root: Path) -> tuple[str, list[str]]:
+    """
+    Guarantee the project's .gitignore covers every sensitive entry.
+
+    Returns (action, entries) where action is:
+        'created' — no .gitignore existed, the full template was written
+        'appended' — an existing file was kept and missing entries added
+        'ok'      — already covered, nothing written
+
+    An existing .gitignore is never overwritten: user rules are preserved and
+    only the missing sensitive entries are appended.
+    """
+    project_root = Path(project_root)
+    gitignore = project_root / '.gitignore'
+
+    if not gitignore.exists():
+        gitignore.write_text(template_content())
+        return 'created', [pat for pat, _ in SENSITIVE_ENTRIES]
+
+    missing = missing_entries(project_root)
+    if not missing:
+        return 'ok', []
+
+    current = gitignore.read_text()
+    block = ['', '# ─── Added by Rocketdoo: secrets that must not be committed ───']
+    block += [pat for pat, _ in missing]
+    suffix = '\n'.join(block) + '\n'
+    gitignore.write_text(current if current.endswith('\n') else current + '\n')
+    with gitignore.open('a') as fh:
+        fh.write(suffix)
+
+    return 'appended', [pat for pat, _ in missing]

--- a/rocketdoo/init_project.py
+++ b/rocketdoo/init_project.py
@@ -12,6 +12,7 @@ from rocketdoo.core.port_validation import (
     collect_declared_ports,
 )
 from rocketdoo.core.edition_setup import setup_enterprise_edition
+from rocketdoo.core.gitignore_manager import ensure_gitignore
 from rocketdoo.core.ssh_manager import (
     list_private_keys,
     copy_key_to_build_context,
@@ -288,6 +289,14 @@ def init_project():
     }
 
     # === Generate files ===
+    # First, so the files rendered below (odoo.conf carries admin_passwd) are
+    # never exposed to a `git add .` in between
+    action, entries = ensure_gitignore(Path(os.getcwd()))
+    if action == "created":
+        click.echo("🔒 .gitignore created (keeps secrets out of git)")
+    elif action == "appended":
+        click.echo(f"🔒 .gitignore updated with {len(entries)} secret rule(s)")
+
     render_template(TEMPLATES_DIR, "Dockerfile.jinja", "Dockerfile", **context)
     render_template(TEMPLATES_DIR, "docker-compose.yaml.jinja", "docker-compose.yaml", **context)
 

--- a/rocketdoo/scaffold.py
+++ b/rocketdoo/scaffold.py
@@ -3,6 +3,11 @@ import shutil
 import click
 from pathlib import Path
 
+from rocketdoo.core.gitignore_manager import ensure_gitignore
+
+# Rendered into .gitignore instead of being copied verbatim
+GITIGNORE_TEMPLATE = ".gitignore.jinja"
+
 def scaffold_project(template="basic", force=False, verbose=False):
     """
     Create the project structure by copying the templates included in Rocketdoo
@@ -28,7 +33,11 @@ def scaffold_project(template="basic", force=False, verbose=False):
         for item in templates_dir.iterdir():
             src = templates_dir / item.name
             dest = target_dir / item.name
-            
+
+            if item.name == GITIGNORE_TEMPLATE:
+                # Handled after the loop so credentials are covered from the start
+                continue
+
             if src.is_dir():
                 # Copy entire directory (including hidden files)
                 if dest.exists():
@@ -53,7 +62,15 @@ def scaffold_project(template="basic", force=False, verbose=False):
                 if verbose:
                     click.echo(f"✅ Copied file: {dest}")
 
+        action, entries = ensure_gitignore(target_dir)
+        if action == "created":
+            click.echo("🔒 .gitignore created (keeps secrets out of git)")
+        elif action == "appended":
+            click.echo(f"🔒 .gitignore updated with {len(entries)} secret rule(s)")
+        elif verbose:
+            click.echo("🔒 .gitignore already covers Rocketdoo secrets")
+
         click.echo("🎉 Project scaffold created successfully.")
-        
+
     except Exception as e:
         click.echo(f"❌ Error during scaffolding: {e}")

--- a/rocketdoo/templates/.gitignore.jinja
+++ b/rocketdoo/templates/.gitignore.jinja
@@ -1,0 +1,48 @@
+# ─────────────────────────────────────────────────────────────────────
+# Secrets and credentials — NEVER commit these
+# ─────────────────────────────────────────────────────────────────────
+# SSH build context: holds the private key copied for private repos
+.ssh/
+# VPS passwords written by `rkd deploy` / `rkd instance`
+.rkd/secrets/
+# PostgreSQL password (Docker secret)
+odoo_pg_pass
+*.env
+!*.env.example
+# Deployment config: contains admin_passwd in clear text
+.rkd/instance.yaml
+# Odoo config: contains admin_passwd in clear text.
+# `rkd init` regenerates it. To version it, commit a sanitized
+# copy as config/odoo.conf.example instead.
+config/odoo.conf
+
+# ─────────────────────────────────────────────────────────────────────
+# Local state, logs and backups
+# ─────────────────────────────────────────────────────────────────────
+.rkd/deploy_backups/
+.rkd/deploy.log
+rkd-shared.json
+
+# ─────────────────────────────────────────────────────────────────────
+# External code — re-fetch instead of committing
+# ─────────────────────────────────────────────────────────────────────
+# Third-party repos cloned by gitman: `gitman install`
+external_addons/
+# Odoo Enterprise: proprietary, licensed separately
+enterprise/
+
+# ─────────────────────────────────────────────────────────────────────
+# Python
+# ─────────────────────────────────────────────────────────────────────
+__pycache__/
+*.py[cod]
+*.egg-info/
+.venv/
+venv/
+
+# ─────────────────────────────────────────────────────────────────────
+# Editors and OS noise
+# ─────────────────────────────────────────────────────────────────────
+*.Identifier
+.DS_Store
+*.swp


### PR DESCRIPTION
## Qué cambia

Un proyecto scaffoldeado guardaba credenciales en disco sin ninguna exclusión de git. Un `git add .` commiteaba la clave SSH privada del contexto de build, los passwords del VPS, el secret de PostgreSQL y el `admin_passwd` de Odoo en claro.

- **`templates/.gitignore.jinja`** — cubre `.ssh/`, `.rkd/secrets/`, `odoo_pg_pass`, `.rkd/instance.yaml`, `config/odoo.conf`, más `external_addons/` y `enterprise/`. Lleva sufijo `.jinja` a propósito: un archivo llamado literalmente `.gitignore` dentro de `rocketdoo/templates/` haría que git lo aplicara al árbol de fuentes de Rocketdoo.
- **`core/gitignore_manager.py`** — `ensure_gitignore()` y `missing_entries()`, compartidos por scaffold, init e info (una sola implementación, sin duplicar).
- **`scaffold` e `init`** lo escriben *antes* de generar los archivos que contienen secretos.
- **`rkd info`** muestra un panel de warning cuando un proyecto existente no tiene cobertura.

Un `.gitignore` existente **nunca se sobreescribe**: se preservan las reglas del usuario y se agregan solo las entradas faltantes (operación idempotente).

## Cómo se probó

```bash
# proyecto nuevo + secrets simulados
rkd scaffold && git init
# .ssh/rsa, .rkd/secrets/*.env, .rkd/instance.yaml, config/odoo.conf, odoo_pg_pass
```

- Los 8 archivos con credenciales quedan ignorados (`git check-ignore` los confirma uno por uno).
- `git add -A` + grep de los valores secretos en el índice: ningún secreto llega a git.
- No queda un `.gitignore.jinja` suelto en el proyecto del usuario.
- Proyecto con `.gitignore` propio: las reglas del usuario se preservan y se agregan las 5 faltantes; segunda ejecución devuelve `ok` (idempotente).
- Panel de warning de `rkd info` verificado en un proyecto sin cobertura.
- `flake8 --select=E9,F63,F7,F82` limpio; `python -m build` + `twine check` OK; el template aparece en el wheel (19 templates).

## Criterios de aceptación

- [x] Un proyecto nuevo incluye `.gitignore` con las rutas sensibles
- [x] `git status` en un proyecto recién creado con secrets generados no lista ningún archivo de credenciales
- [x] Warning visible en proyectos existentes sin `.gitignore`
- [x] Documentado en README.md (CLAUDE.md actualizado en local: está en el `.gitignore` del repo)

Refs #134
