### PR TITLE
FIX: reutiliza el odoo_pg_pass entre deploys de instancia

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,6 @@
 include README.md
 include LICENSE
+include rocketdoo/templates/.gitignore.jinja
 include rocketdoo/templates/deploy/.deployignore
 include rocketdoo/templates/deploy/deploy.yaml.jinja
 recursive-include rocketdoo/templates *

--- a/README.md
+++ b/README.md
@@ -473,6 +473,37 @@ Additional interface features:
 
 ---
 
+### Instance secrets and re-deploys
+
+`rkd instance deploy` needs its passwords to stay the same across deploys.
+PostgreSQL only applies the password while initialising its data directory and
+ignores it afterwards, so a fresh password on a later deploy would leave Odoo
+unable to authenticate against its own database.
+
+Both the PostgreSQL password and the Odoo master password are therefore
+generated **once** and stored in `.rkd/secrets/instance_<env>_db.env` (mode
+`600`, git-ignored). Later deploys reuse them, so re-deploying is safe and the
+passwords stay recoverable:
+
+```bash
+cat .rkd/secrets/instance_stage_db.env
+```
+
+If an environment was first deployed with Rocketdoo ≤ 3.1.6, the password
+already on the VPS is adopted automatically and stored locally on the next
+deploy — no manual step needed.
+
+> Recovering an environment already broken by the old behaviour: the database
+> keeps the password from its **first** deploy, which was not saved anywhere. Reset
+> the role on the VPS and let the next deploy take over:
+>
+> ```bash
+> # on the VPS, inside <remote_path>/<env>/
+> docker compose exec db psql -U <db_user> -c "ALTER ROLE <db_user> PASSWORD '$(cat odoo_pg_pass)';"
+> ```
+
+---
+
 ### Technical Support
 
 - If you have any questions or issues with our development environment, you can contact us and submit your inquiry or support ticket by clicking on the link below.

--- a/README.md
+++ b/README.md
@@ -473,6 +473,31 @@ Additional interface features:
 
 ---
 
+### Keeping secrets out of git
+
+A Rocketdoo project keeps credentials on disk: the SSH private key copied into
+the build context, the PostgreSQL secret, and the Odoo master password written
+into config files. `rkd scaffold` and `rkd init` therefore always write a
+`.gitignore` covering them:
+
+| Path | Why it must not be committed |
+|------|------------------------------|
+| `.ssh/` | SSH private key copied into the Docker build context |
+| `.rkd/secrets/` | VPS passwords for `rkd deploy` and `rkd instance` |
+| `odoo_pg_pass` | PostgreSQL password (Docker secret) |
+| `.rkd/instance.yaml` | Deployment config, holds `admin_passwd` in clear text |
+| `config/odoo.conf` | Odoo config, holds `admin_passwd` in clear text |
+
+An existing `.gitignore` is never overwritten — your own rules are kept and only
+the missing entries are appended. `rkd info` warns when a project is missing
+coverage; run `rkd scaffold` in it to fix it.
+
+> `config/odoo.conf` is ignored because `rkd init` regenerates it and it carries
+> the master password. If your team needs to version it, commit a sanitized copy
+> as `config/odoo.conf.example`.
+
+---
+
 ### Technical Support
 
 - If you have any questions or issues with our development environment, you can contact us and submit your inquiry or support ticket by clicking on the link below.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ include = ["rocketdoo*"]
 # 🚀 Include templates in the package
 [tool.setuptools.package-data]
 rocketdoo = [
+    "templates/.gitignore.jinja",
     "templates/**/*",
     "templates/**/**/*",
     "templates/**/.vscode/*",

--- a/rocketdoo/cli.py
+++ b/rocketdoo/cli.py
@@ -9,6 +9,7 @@ from rich import box
 from .scaffold import scaffold_project
 from .init_project import init_project
 from .project_info import get_project_info, project_exists
+from rocketdoo.core.gitignore_manager import missing_entries
 from rocketdoo import __version__
 import questionary
 from rocketdoo.docker_cli import docker, up, down, status, stop, pause, logs, build, restart
@@ -396,6 +397,21 @@ def info():
             padding=(1, 1)
         ))
     
+    # Warn if secrets in this project could be committed
+    missing = missing_entries(Path.cwd())
+    if missing:
+        warn = Text()
+        warn.append("⚠️  These files hold credentials and are not ignored by git:\n\n", style="bold yellow")
+        for pattern, why in missing:
+            warn.append(f"   {pattern}", style="bold")
+            warn.append(f" — {why}\n", style="dim")
+        warn.append("\n💡 Fix it with: ", style="dim")
+        warn.append("rkd scaffold", style="bold cyan")
+        warn.append(" (keeps your existing rules)", style="dim")
+        console.print()
+        console.print(Panel(warn, title="[bold yellow]Secrets at risk[/bold yellow]",
+                            border_style="yellow", box=box.ROUNDED, padding=(1, 1)))
+
     # Footer with framework information
     console.print()
     footer_text = Text()

--- a/rocketdoo/core/gitignore_manager.py
+++ b/rocketdoo/core/gitignore_manager.py
@@ -1,0 +1,86 @@
+"""
+RocketDoo - .gitignore management for generated projects.
+
+A Rocketdoo project holds credentials on disk (the SSH build context, the
+PostgreSQL secret, admin passwords inside config files). Without a .gitignore
+a plain `git add .` commits all of them, so scaffold/init always write one and
+`rkd info` warns when an existing project is missing coverage.
+
+The template lives at templates/.gitignore.jinja — named with the .jinja
+suffix so git does not apply it to Rocketdoo's own source tree.
+"""
+from pathlib import Path
+
+_TEMPLATE = Path(__file__).parent.parent / 'templates' / '.gitignore.jinja'
+
+# Entries that must be present for credentials to stay out of the repo.
+# Kept deliberately short: these are the leak vectors, not the full template.
+SENSITIVE_ENTRIES = [
+    ('.ssh/', 'SSH private key copied into the build context'),
+    ('.rkd/secrets/', 'VPS passwords'),
+    ('odoo_pg_pass', 'PostgreSQL password'),
+    ('.rkd/instance.yaml', 'deployment config with admin_passwd'),
+    ('config/odoo.conf', 'Odoo config with admin_passwd'),
+]
+
+
+def template_content() -> str:
+    """Return the canonical .gitignore shipped with Rocketdoo."""
+    return _TEMPLATE.read_text()
+
+
+def _entries(text: str) -> set[str]:
+    """Non-comment, non-empty lines of a .gitignore."""
+    return {
+        line.strip()
+        for line in text.splitlines()
+        if line.strip() and not line.lstrip().startswith('#')
+    }
+
+
+def missing_entries(project_root: Path) -> list[tuple[str, str]]:
+    """
+    Return the sensitive entries a project's .gitignore does not cover.
+
+    A missing .gitignore returns every entry.
+    """
+    gitignore = Path(project_root) / '.gitignore'
+    if not gitignore.exists():
+        return list(SENSITIVE_ENTRIES)
+
+    present = _entries(gitignore.read_text())
+    return [(pat, why) for pat, why in SENSITIVE_ENTRIES if pat not in present]
+
+
+def ensure_gitignore(project_root: Path) -> tuple[str, list[str]]:
+    """
+    Guarantee the project's .gitignore covers every sensitive entry.
+
+    Returns (action, entries) where action is:
+        'created' — no .gitignore existed, the full template was written
+        'appended' — an existing file was kept and missing entries added
+        'ok'      — already covered, nothing written
+
+    An existing .gitignore is never overwritten: user rules are preserved and
+    only the missing sensitive entries are appended.
+    """
+    project_root = Path(project_root)
+    gitignore = project_root / '.gitignore'
+
+    if not gitignore.exists():
+        gitignore.write_text(template_content())
+        return 'created', [pat for pat, _ in SENSITIVE_ENTRIES]
+
+    missing = missing_entries(project_root)
+    if not missing:
+        return 'ok', []
+
+    current = gitignore.read_text()
+    block = ['', '# ─── Added by Rocketdoo: secrets that must not be committed ───']
+    block += [pat for pat, _ in missing]
+    suffix = '\n'.join(block) + '\n'
+    gitignore.write_text(current if current.endswith('\n') else current + '\n')
+    with gitignore.open('a') as fh:
+        fh.write(suffix)
+
+    return 'appended', [pat for pat, _ in missing]

--- a/rocketdoo/core/instance/deployer_docker.py
+++ b/rocketdoo/core/instance/deployer_docker.py
@@ -8,9 +8,7 @@ Build flow (requires SSH agent for gitman private repos):
   VPS   → docker compose up -d
 """
 import os
-import secrets
 import shutil
-import string
 import subprocess
 import tempfile
 from pathlib import Path
@@ -24,15 +22,12 @@ from .config_manager import (
     PG_PROFILES,
     WORKERS_BY_ENV,
 )
+from .secrets_store import ADMIN_PASSWD, PG_PASS, load, random_password, save
 from .ssh_utils import build_rsync_cmd, build_ssh_cmd, resolve_auth
 
 console = Console()
 
 _TEMPLATES_DIR = Path(__file__).parent.parent.parent / 'templates' / 'instance'
-
-
-def _random_password(n: int = 20) -> str:
-    return ''.join(secrets.choice(string.ascii_letters + string.digits) for _ in range(n))
 
 
 class DockerInstanceDeployer:
@@ -76,7 +71,7 @@ class DockerInstanceDeployer:
             tmp_path = Path(tmp)
 
             console.print('[dim]Step 1/5 — Rendering configuration files...[/dim]')
-            self._render_templates(tmp_path)
+            self._render_templates(tmp_path, allow_remote_lookup=not dry_run)
             console.print('[green]✓[/green] Configuration files rendered')
 
             if dry_run:
@@ -106,9 +101,58 @@ class DockerInstanceDeployer:
 
         return True
 
+    # ─── secrets ─────────────────────────────────────────────────────────────
+
+    def _resolve_secrets(self, allow_remote_lookup: bool = True) -> dict[str, str]:
+        """
+        Resolve this environment's passwords, reusing any that already exist.
+
+        PostgreSQL sets the role password when it initialises the cluster and
+        ignores POSTGRES_PASSWORD_FILE afterwards, so a regenerated password on
+        a second deploy would lock Odoo out of the database.
+
+        Precedence: local secret store → password already on the VPS → new one.
+        """
+        stored = load(self.project_path, self.env)
+        pg_pass = stored.get(PG_PASS)
+        admin_passwd = self.cfg.get('admin_passwd') or stored.get(ADMIN_PASSWD)
+
+        if not pg_pass and allow_remote_lookup:
+            pg_pass = self._read_remote_pg_pass()
+            if pg_pass:
+                console.print('[dim]  Reusing odoo_pg_pass already deployed on the VPS[/dim]')
+
+        generated = []
+        if not pg_pass:
+            pg_pass = random_password(32)
+            generated.append('odoo_pg_pass')
+        if not admin_passwd:
+            admin_passwd = random_password()
+            generated.append('admin_passwd')
+
+        path = save(self.project_path, self.env, {PG_PASS: pg_pass, ADMIN_PASSWD: admin_passwd})
+        if generated:
+            console.print(f'[green]✔[/green] Generated {" and ".join(generated)}')
+        console.print(f'[dim]  Secrets stored in {path}[/dim]')
+
+        return {'pg_pass': pg_pass, 'admin_passwd': admin_passwd}
+
+    def _read_remote_pg_pass(self) -> str | None:
+        """Return odoo_pg_pass from a previous deploy, or None if unavailable."""
+        remote_file = f'{self.remote_path}/{self.env}/odoo_pg_pass'
+        cmd = build_ssh_cmd(
+            self.auth, self.port, self.user, self.host,
+            f'cat {remote_file} 2>/dev/null',
+        )
+        try:
+            result = subprocess.run(cmd, capture_output=True, text=True, timeout=60)
+        except (subprocess.SubprocessError, OSError):
+            return None
+        return result.stdout.strip() or None
+
     # ─── template rendering ───────────────────────────────────────────────────
 
-    def _render_templates(self, tmp: Path):
+    def _render_templates(self, tmp: Path, allow_remote_lookup: bool = True):
         """Render all Jinja2 templates into a temporary directory."""
         jinja_env = Environment(
             loader=FileSystemLoader(str(_TEMPLATES_DIR)),
@@ -116,11 +160,13 @@ class DockerInstanceDeployer:
             lstrip_blocks=True,
         )
 
+        creds = self._resolve_secrets(allow_remote_lookup=allow_remote_lookup)
+
         db_user = self.cfg.get('db_user', f'odoo_{self.env}')
         use_enterprise = self.cfg.get('use_enterprise', False)
         use_gitman = self.cfg.get('use_gitman', False)
         gitman_config = self.cfg.get('gitman_config', 'gitman.yml')
-        admin_passwd = self.cfg.get('admin_passwd', _random_password())
+        admin_passwd = creds['admin_passwd']
 
         ctx = {
             'environment': self.env,
@@ -159,9 +205,8 @@ class DockerInstanceDeployer:
         odoo_conf = jinja_env.get_template('odoo.conf.jinja').render(**ctx)
         (config_dir / 'odoo.conf').write_text(odoo_conf)
 
-        # {env}/odoo_pg_pass
-        pg_pass = _random_password(32)
-        (env_dir / 'odoo_pg_pass').write_text(pg_pass)
+        # {env}/odoo_pg_pass — reused across deploys, never regenerated
+        (env_dir / 'odoo_pg_pass').write_text(creds['pg_pass'])
 
         # gitman config (if enabled and local file exists)
         if use_gitman and gitman_config:

--- a/rocketdoo/core/instance/deployer_native.py
+++ b/rocketdoo/core/instance/deployer_native.py
@@ -17,6 +17,7 @@ from pathlib import Path
 from rich.console import Console
 
 from .config_manager import LOG_LEVEL_BY_ENV, MEMORY_BY_ENV, WORKERS_BY_ENV
+from .secrets_store import ADMIN_PASSWD, load, random_password, save
 from .ssh_utils import build_rsync_cmd, build_ssh_cmd, resolve_auth
 
 console = Console()
@@ -110,9 +111,29 @@ class NativeInstanceDeployer:
     def _install_odoo(self) -> bool:
         return self._ssh('sudo apt-get install -y odoo')
 
+    def _resolve_admin_passwd(self) -> str:
+        """
+        Return the Odoo master password, generating one only on first deploy.
+
+        Reused from the local secret store so it stays stable across deploys
+        and remains recoverable (it used to default to the literal 'admin').
+        """
+        configured = self.cfg.get('admin_passwd')
+        if configured:
+            return configured
+
+        stored = load(self.project_path, self.env).get(ADMIN_PASSWD)
+        if stored:
+            return stored
+
+        generated = random_password()
+        path = save(self.project_path, self.env, {ADMIN_PASSWD: generated})
+        console.print(f'[green]✔[/green] Generated admin_passwd, stored in {path}')
+        return generated
+
     def _configure_odoo(self) -> bool:
         db_user = self.cfg.get('db_user', f'odoo_{self.env}')
-        admin_passwd = self.cfg.get('admin_passwd', 'admin')
+        admin_passwd = self._resolve_admin_passwd()
         workers = WORKERS_BY_ENV.get(self.env, 2)
         log_level = LOG_LEVEL_BY_ENV.get(self.env, 'info')
         mem = MEMORY_BY_ENV[self.env]

--- a/rocketdoo/core/instance/secrets_store.py
+++ b/rocketdoo/core/instance/secrets_store.py
@@ -1,0 +1,58 @@
+"""
+RocketDoo Instance - persistent secret storage.
+
+Instance passwords must survive across deploys. PostgreSQL only applies
+POSTGRES_PASSWORD_FILE while initialising the cluster, so generating a fresh
+odoo_pg_pass on a later deploy leaves Odoo unable to authenticate against its
+own database — and the value was previously discarded with the temporary build
+directory, so it could not be recovered either.
+
+Secrets live in .rkd/secrets/instance_{env}_db.env (0600), alongside the VPS
+credentials written by ssh_utils.resolve_auth().
+"""
+import secrets
+import stat
+import string
+from pathlib import Path
+
+PG_PASS = 'ODOO_PG_PASS'
+ADMIN_PASSWD = 'ODOO_ADMIN_PASSWD'
+
+_HEADER = '# Rocketdoo instance secrets - do not commit\n'
+
+
+def random_password(length: int = 20) -> str:
+    alphabet = string.ascii_letters + string.digits
+    return ''.join(secrets.choice(alphabet) for _ in range(length))
+
+
+def secrets_file(project_path: Path, env: str) -> Path:
+    return Path(project_path) / '.rkd' / 'secrets' / f'instance_{env}_db.env'
+
+
+def load(project_path: Path, env: str) -> dict[str, str]:
+    """Return the stored secrets for an environment ({} if none yet)."""
+    path = secrets_file(project_path, env)
+    if not path.exists():
+        return {}
+
+    values = {}
+    for line in path.read_text().splitlines():
+        line = line.strip()
+        if not line or line.startswith('#') or '=' not in line:
+            continue
+        key, _, value = line.partition('=')
+        values[key.strip()] = value.strip()
+    return values
+
+
+def save(project_path: Path, env: str, values: dict[str, str]) -> Path:
+    """Merge values into the environment's secret file and return its path."""
+    path = secrets_file(project_path, env)
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    merged = {**load(project_path, env), **values}
+    body = ''.join(f'{key}={value}\n' for key, value in sorted(merged.items()))
+    path.write_text(_HEADER + body)
+    path.chmod(stat.S_IRUSR | stat.S_IWUSR)
+    return path

--- a/rocketdoo/init_project.py
+++ b/rocketdoo/init_project.py
@@ -12,6 +12,7 @@ from rocketdoo.core.port_validation import (
     collect_declared_ports,
 )
 from rocketdoo.core.edition_setup import setup_enterprise_edition
+from rocketdoo.core.gitignore_manager import ensure_gitignore
 from rocketdoo.core.ssh_manager import (
     list_private_keys,
     copy_key_to_build_context,
@@ -288,6 +289,14 @@ def init_project():
     }
 
     # === Generate files ===
+    # First, so the files rendered below (odoo.conf carries admin_passwd) are
+    # never exposed to a `git add .` in between
+    action, entries = ensure_gitignore(Path(os.getcwd()))
+    if action == "created":
+        click.echo("🔒 .gitignore created (keeps secrets out of git)")
+    elif action == "appended":
+        click.echo(f"🔒 .gitignore updated with {len(entries)} secret rule(s)")
+
     render_template(TEMPLATES_DIR, "Dockerfile.jinja", "Dockerfile", **context)
     render_template(TEMPLATES_DIR, "docker-compose.yaml.jinja", "docker-compose.yaml", **context)
 

--- a/rocketdoo/scaffold.py
+++ b/rocketdoo/scaffold.py
@@ -3,6 +3,11 @@ import shutil
 import click
 from pathlib import Path
 
+from rocketdoo.core.gitignore_manager import ensure_gitignore
+
+# Rendered into .gitignore instead of being copied verbatim
+GITIGNORE_TEMPLATE = ".gitignore.jinja"
+
 def scaffold_project(template="basic", force=False, verbose=False):
     """
     Create the project structure by copying the templates included in Rocketdoo
@@ -28,7 +33,11 @@ def scaffold_project(template="basic", force=False, verbose=False):
         for item in templates_dir.iterdir():
             src = templates_dir / item.name
             dest = target_dir / item.name
-            
+
+            if item.name == GITIGNORE_TEMPLATE:
+                # Handled after the loop so credentials are covered from the start
+                continue
+
             if src.is_dir():
                 # Copy entire directory (including hidden files)
                 if dest.exists():
@@ -53,7 +62,15 @@ def scaffold_project(template="basic", force=False, verbose=False):
                 if verbose:
                     click.echo(f"✅ Copied file: {dest}")
 
+        action, entries = ensure_gitignore(target_dir)
+        if action == "created":
+            click.echo("🔒 .gitignore created (keeps secrets out of git)")
+        elif action == "appended":
+            click.echo(f"🔒 .gitignore updated with {len(entries)} secret rule(s)")
+        elif verbose:
+            click.echo("🔒 .gitignore already covers Rocketdoo secrets")
+
         click.echo("🎉 Project scaffold created successfully.")
-        
+
     except Exception as e:
         click.echo(f"❌ Error during scaffolding: {e}")

--- a/rocketdoo/templates/.gitignore.jinja
+++ b/rocketdoo/templates/.gitignore.jinja
@@ -1,0 +1,48 @@
+# ─────────────────────────────────────────────────────────────────────
+# Secrets and credentials — NEVER commit these
+# ─────────────────────────────────────────────────────────────────────
+# SSH build context: holds the private key copied for private repos
+.ssh/
+# VPS passwords written by `rkd deploy` / `rkd instance`
+.rkd/secrets/
+# PostgreSQL password (Docker secret)
+odoo_pg_pass
+*.env
+!*.env.example
+# Deployment config: contains admin_passwd in clear text
+.rkd/instance.yaml
+# Odoo config: contains admin_passwd in clear text.
+# `rkd init` regenerates it. To version it, commit a sanitized
+# copy as config/odoo.conf.example instead.
+config/odoo.conf
+
+# ─────────────────────────────────────────────────────────────────────
+# Local state, logs and backups
+# ─────────────────────────────────────────────────────────────────────
+.rkd/deploy_backups/
+.rkd/deploy.log
+rkd-shared.json
+
+# ─────────────────────────────────────────────────────────────────────
+# External code — re-fetch instead of committing
+# ─────────────────────────────────────────────────────────────────────
+# Third-party repos cloned by gitman: `gitman install`
+external_addons/
+# Odoo Enterprise: proprietary, licensed separately
+enterprise/
+
+# ─────────────────────────────────────────────────────────────────────
+# Python
+# ─────────────────────────────────────────────────────────────────────
+__pycache__/
+*.py[cod]
+*.egg-info/
+.venv/
+venv/
+
+# ─────────────────────────────────────────────────────────────────────
+# Editors and OS noise
+# ─────────────────────────────────────────────────────────────────────
+*.Identifier
+.DS_Store
+*.swp


### PR DESCRIPTION
## Qué cambia

`deployer_docker` generaba un `odoo_pg_pass` aleatorio nuevo en **cada** deploy. PostgreSQL fija el password del rol al inicializar el cluster e ignora `POSTGRES_PASSWORD_FILE` después, así que el segundo `rkd instance deploy` sobre el mismo entorno dejaba a Odoo sin poder autenticarse contra su propia base de datos. El valor tampoco quedaba registrado en ningún lado: se descartaba junto con el directorio temporal del build.

- **`core/instance/secrets_store.py`** — persiste los passwords en `.rkd/secrets/instance_{env}_db.env` con permisos `600`.
- **`_resolve_secrets()`** — precedencia: store local → password ya presente en el VPS → generar uno nuevo. Los entornos desplegados con ≤ 3.1.6 **adoptan el password remoto** en el próximo deploy, sin paso manual.
- El **dry-run no consulta el VPS** (no hace SSH).
- **`deployer_native`** — el `admin_passwd` usaba el literal `'admin'` como default; ahora se genera una vez y queda recuperable en el mismo store.

## Cómo se probó

**Regresión demostrada:** con el código de `dev/v3`, dos renders consecutivos producen passwords distintos (`ZZAnp9PL…` vs `pwAMa4pk…`). Con el fix, tres deploys simulados devuelven el mismo valor.

| Verificación | Resultado |
|---|---|
| Password estable en 3 deploys consecutivos | OK |
| Longitud 32 preservada | OK |
| Permisos del archivo de secrets | `600` |
| Password recuperable (`cat` del .env) | OK |
| Adopta el `odoo_pg_pass` ya presente en el VPS | OK |
| Lo persiste localmente tras adoptarlo | OK |
| `admin_passwd` estable en `odoo.conf` entre deploys | OK |
| `dry-run` no ejecuta SSH | OK (0 llamadas) |

`flake8 --select=E9,F63,F7,F82` limpio. Los imports que mi cambio dejó huérfanos (`secrets`, `string`) fueron removidos; `os` y `remote` sin usar son preexistentes (verificado contra `dev/v3`) y quedan para E2/E8.

> El fix depende de que `.rkd/secrets/` esté git-ignoreado, que es exactamente lo que agrega #134 (PR #149).

## Criterios de aceptación

- [x] Dos `rkd instance deploy --env stage` consecutivos funcionan y Odoo conecta a la DB
- [x] El password queda persistido localmente con `600` y es recuperable
- [x] `admin_passwd` generado también queda persistido
- [x] Procedimiento de prueba documentado (arriba, y vía de recuperación para entornos ya rotos en el README)

Refs #135
