### PR TITLE
FIX: el build de Docker ahora funciona en Odoo 15-19

### DIFF
--- a/rocketdoo/templates/Dockerfile.jinja
+++ b/rocketdoo/templates/Dockerfile.jinja
@@ -10,19 +10,24 @@ COPY ./install_dependencies.sh /usr/lib/python3/dist-packages/odoo/
 
 USER root
 
-# Deshabilitar la restricción de externally-managed-environment
+# Permite instalar con pip en la imagen base.
+# No usar --break-system-packages: llegó en pip 23 y las imágenes base viejas
+# no lo soportan (odoo:15.0/16.0 = Debian bullseye, pip 20.3; odoo:17.0 =
+# Ubuntu jammy, pip 22.0). Borrar EXTERNALLY-MANAGED sirve en todas: donde el
+# archivo no existe, el rm -f no falla.
 RUN rm -f /usr/lib/python*/EXTERNALLY-MANAGED
 
-# O alternativamente, configurar pip
-RUN pip config set global.break-system-packages true
-
+# pipx no está en los repos de Debian bullseye (odoo:15.0/16.0). Es una
+# conveniencia para trabajar dentro del contenedor, no un requisito del build,
+# así que su ausencia no debe abortar la imagen.
 RUN apt update && \
     apt install -y libssl-dev swig python3-dev gcc && \
     apt install -y python3-m2crypto && \
-    apt install -y git pipx && \
+    apt install -y git && \
+    { apt install -y pipx || echo "pipx no disponible en esta imagen base, se omite"; } && \
     apt clean && \
     rm -rf /var/lib/apt/lists/* && \
-    python3 -m pip install debugpy gitman --break-system-packages
+    python3 -m pip install debugpy gitman
 
 #RUN mkdir -p /root/.ssh
 #COPY ./.ssh/rsa /root/.ssh/id_rsa

--- a/rocketdoo/templates/install_dependencies.sh
+++ b/rocketdoo/templates/install_dependencies.sh
@@ -10,10 +10,9 @@ if [ -f "$file_to_check" ]; then
         # Detectar la versión de pip para decidir si usar --break-system-packages
         pip_version=$(pip --version | awk '{print $2}')
         pip_major=$(echo "$pip_version" | cut -d. -f1)
-        pip_minor=$(echo "$pip_version" | cut -d. -f2)
-        
-        # Usar --break-system-packages solo si pip >= 22.1
-        if [ "$pip_major" -gt 22 ] || ([ "$pip_major" -eq 22 ] && [ "$pip_minor" -ge 1 ]); then
+
+        # El flag existe desde pip 23.0; odoo:15.0-17.0 traen pip 22 y fallan con él
+        if [ "$pip_major" -ge 23 ]; then
             output=$(pip install --break-system-packages -r "$file_to_check" 2>&1)
         else
             # Para versiones antiguas de pip, usar sin la opción


### PR DESCRIPTION
## Qué cambia

`rkd up` fallaba en el build para **Odoo 15.0, 16.0 y 17.0** — tres de las cinco versiones que ofrece `rkd init`. Resultaron ser **dos causas distintas**, ambas por asumir una única imagen base:

### 1. `--break-system-packages` (la del reporte original)

El flag llegó en pip 23.0, pero las imágenes viejas traen pip anterior. Se elimina del `pip install`: el `rm -f /usr/lib/python*/EXTERNALLY-MANAGED` que ya estaba arriba cubre las imágenes nuevas, y donde el archivo no existe el `rm -f` no falla.

### 2. `pipx` no existe en Debian bullseye (descubierta al implementar)

Con el flag corregido, 15.0 y 16.0 seguían fallando pero con `exit code 100` (apt, no pip): `E: Unable to locate package pipx`. La matriz de imágenes base es más variada de lo que suponía el reporte:

| Imagen | Distro | pip | `pipx` en apt |
|---|---|---|---|
| `odoo:15.0`, `odoo:16.0` | Debian **bullseye** | 20.3.4 | **no** |
| `odoo:17.0` | Ubuntu jammy | 22.0.2 | sí |
| `odoo:18.0`, `odoo:19.0` | Ubuntu noble | 24.0 | sí |

`pipx` **no se usa en ninguna parte del proyecto** (cero referencias en el código Python y en el resto de las plantillas): es una conveniencia para trabajar dentro del contenedor, no un requisito del build. Su instalación pasa a ser tolerante en lugar de abortar la imagen.

### 3. Mismo bug con umbral incorrecto en `install_dependencies.sh`

El script decidía usar el flag para pip `>= 22.1`, cuando en realidad requiere pip `>= 23.0`. Con pip 20.3/22.0 zafaba por caer en el `else`, pero cualquier pip 22.1–22.3 habría fallado. Corregido a `>= 23`.

## Cómo se probó

Builds con `--no-cache` del **template real renderizado** (no de un Dockerfile de prueba), verificando además que las herramientas funcionen *dentro* de cada imagen:

| Odoo | build | debugpy | gitman | git | M2Crypto |
|---|---|---|---|---|---|
| 15.0 | OK | 1.8.21 | v3.7 | 2.30.2 | ok |
| 16.0 | OK | 1.8.21 | v3.7 | 2.30.2 | ok |
| 17.0 | OK | 1.8.21 | v3.8.1 | 2.34.1 | ok |
| 18.0 | OK | 1.8.21 | v3.8.1 | 2.43.0 | ok |
| 19.0 | OK | 1.8.21 | v3.8.1 | 2.43.0 | ok |

`bash -n` sobre `install_dependencies.sh` y verificación de la tabla de decisión del umbral (pip 22.0.2 y 22.3 → sin flag; 23.0 y 24.0 → con flag).

> Nota: al escribir el fix puse un comentario `#` dentro de la cadena de continuaciones `\` del `RUN`, lo que habría comentado el resto de la línea lógica y roto el build. Los comentarios quedaron como comentarios de Dockerfile, fuera de la continuación, y está verificado con un chequeo explícito.

## Criterios de aceptación

- [x] `rkd up` construye y levanta con Odoo 15.0, 16.0, 17.0, 18.0 y 19.0
- [ ] Cubierto por los snapshots de render y el test E2E de scaffold (#136 — pendiente de esa épica)
- [x] La matriz de distro/pip por imagen base queda documentada (en el template y en #152, insumo para #139)

Refs #152
