### PR TITLE
FEAT: modelos de dominio Pydantic compartidos CLI+API (E3)

### DIFF
--- a/rocketdoo/core/deploy/base.py
+++ b/rocketdoo/core/deploy/base.py
@@ -6,28 +6,13 @@ Abstract base class for all deployers
 from abc import ABC, abstractmethod
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import Dict, List
 
 from rich.console import Console
 
+from rocketdoo.core.models import DeploymentResult
+
 console = Console()
-
-
-class DeploymentResult:
-    """Result of a deployment operation"""
-
-    def __init__(self, success: bool, message: str, details: Optional[Dict] = None):
-        self.success = success
-        self.message = message
-        self.details = details or {}
-        self.timestamp = datetime.now()
-
-    def __bool__(self):
-        return self.success
-
-    def __str__(self):
-        status = "✅ SUCCESS" if self.success else "❌ FAILED"
-        return f"{status}: {self.message}"
 
 
 class BaseDeployer(ABC):

--- a/rocketdoo/core/deploy/config_manager.py
+++ b/rocketdoo/core/deploy/config_manager.py
@@ -8,9 +8,12 @@ from typing import Dict, List, Optional
 
 import questionary
 import yaml
+from pydantic import ValidationError
 from questionary import Style
 from rich.console import Console
 from rich.prompt import Confirm, Prompt
+
+from rocketdoo.core.models import DeployConfig
 
 console = Console()
 
@@ -28,6 +31,15 @@ custom_style = Style(
         ("text", ""),
     ]
 )
+
+
+def _readable_errors(exc: ValidationError) -> List[str]:
+    """Turn pydantic's report into the field-named messages the CLI prints."""
+    messages = []
+    for error in exc.errors():
+        location = ".".join(str(part) for part in error["loc"]) or "config"
+        messages.append(f"{location}: {error['msg']}")
+    return messages
 
 
 class DeployConfigManager:
@@ -94,50 +106,11 @@ class DeployConfigManager:
         Returns:
             List of errors (empty if OK)
         """
-        errors = []
-
-        # Validate basic structure
-        if "modules" not in config:
-            errors.append("Missing 'modules' section")
-
-        if "targets" not in config:
-            errors.append("Missing 'targets' section")
-        elif not config["targets"]:
-            errors.append("No deployment targets configured")
-
-        # Validate each target
-        for target_name, target_config in config.get("targets", {}).items():
-            if "type" not in target_config:
-                errors.append(f"Target '{target_name}': missing 'type' field")
-
-            target_type = target_config.get("type")
-
-            # Validate VPS
-            if target_type == "vps":
-                if "connection" not in target_config:
-                    errors.append(f"Target '{target_name}': missing 'connection' section")
-                else:
-                    conn = target_config["connection"]
-                    required = ["host", "user"]
-                    for field in required:
-                        if field not in conn:
-                            errors.append(f"Target '{target_name}': missing connection.{field}")
-
-                if "deployment_type" not in target_config:
-                    errors.append(f"Target '{target_name}': missing 'deployment_type'")
-
-            # Validate Odoo.sh
-            elif target_type == "odoo-sh":
-                if "odoo_sh" not in target_config:
-                    errors.append(f"Target '{target_name}': missing 'odoo_sh' section")
-                else:
-                    odoo_sh = target_config["odoo_sh"]
-                    required = ["project_id", "branch"]
-                    for field in required:
-                        if field not in odoo_sh:
-                            errors.append(f"Target '{target_name}': missing odoo_sh.{field}")
-
-        return errors
+        try:
+            parsed = DeployConfig.model_validate(config)
+        except ValidationError as exc:
+            return _readable_errors(exc)
+        return parsed.validation_errors()
 
     def get_default_config(self) -> Dict:
         """

--- a/rocketdoo/core/instance/config_manager.py
+++ b/rocketdoo/core/instance/config_manager.py
@@ -13,6 +13,7 @@ from questionary import Style
 from rich.console import Console
 from rich.prompt import Confirm, Prompt
 
+from rocketdoo.core.models import InstanceConfig
 from rocketdoo.core.ssh_manager import list_private_keys
 
 console = Console()
@@ -84,7 +85,10 @@ class InstanceConfigManager:
     def load(self) -> dict:
         if not self.exists():
             raise FileNotFoundError(f"Instance config not found: {self.config_path}")
-        return yaml.safe_load(self.config_path.read_text()) or {}
+        raw = yaml.safe_load(self.config_path.read_text()) or {}
+        # Normalise through the model so a file written by an older GUI (flat
+        # connection fields, no `environments` wrapper) still deploys.
+        return InstanceConfig.model_validate(raw).to_yaml_dict()
 
     def save(self, config: dict):
         self.config_path.parent.mkdir(parents=True, exist_ok=True)

--- a/rocketdoo/core/models/README.md
+++ b/rocketdoo/core/models/README.md
@@ -1,0 +1,96 @@
+# Esquemas de configuración
+
+Definición única de los archivos de configuración de Rocketdoo, compartida por
+la CLI, la GUI/API y los deployers. Antes de estos modelos cada consumidor
+tenía su propia idea del esquema, y la GUI y los deployers no coincidían: los
+`.rkd/instance.yaml` escritos desde la GUI fallaban con `KeyError: 'vps'` al
+desplegar.
+
+## `.rkd/instance.yaml` — `InstanceConfig`
+
+Forma canónica, la que se escribe siempre:
+
+```yaml
+environments:
+  stage:
+    type: docker              # docker | native
+    vps:
+      host: vps.example.com
+      port: 22
+      user: ubuntu
+      auth_method: ssh_key    # ssh_key | password
+      ssh_key: ~/.ssh/id_ed25519
+      password: ""            # literal o "${VAR}"; excluyente con ssh_key
+    odoo_version: "17.0"
+    odoo_tag: "17.0"          # por defecto, igual a odoo_version
+    domain: stage.example.com
+    traefik_email: ops@example.com
+    db_version: "16"
+    db_user: odoo_stage
+    admin_passwd: "..."
+    use_enterprise: false
+    use_gitman: false
+    gitman_config: ""
+    pg_profile: small         # small | medium | large
+    remote_path: /opt/odoo-stage
+```
+
+### Formas que el lector acepta
+
+El lector es tolerante para no romper proyectos existentes. Estas tres entradas
+producen el mismo modelo, y al guardarse quedan en la forma canónica:
+
+| Forma | Origen |
+|---|---|
+| Conexión anidada bajo `vps:` | Wizard `rkd instance init` |
+| Campos de conexión planos en el entorno | GUI anterior a v3.2 |
+| Sin la clave `environments:` de primer nivel | Lector de la GUI anterior a v3.2 |
+
+También se aceptan dos nombres antiguos de la GUI: `password_ref` → `password`
+y `email` → `traefik_email`.
+
+Campos desconocidos se rechazan (`extra="forbid"`): un `odoo_verison` mal
+escrito falla al validar en vez de ignorarse en silencio.
+
+## `.rkd/deploy.yaml` — `DeployConfig`
+
+```yaml
+modules:
+  auto_detect: true
+  base_path: addons
+  exclude_patterns: ["*/tests/*", "*/__pycache__/*"]
+targets:
+  production:
+    type: vps                 # vps | odoo-sh
+    deployment_type: docker   # docker | native   (sólo type: vps)
+    connection:               # sólo type: vps
+      host: vps.example.com
+      user: odoo
+      port: 22
+      ssh_key: ~/.ssh/id_rsa
+      password: ""            # excluyente con ssh_key
+  staging:
+    type: odoo-sh
+    odoo_sh:
+      project_id: abc123
+      branch: production
+```
+
+`validation_errors()` devuelve mensajes que nombran el campo
+(`Target 'production': missing connection.host`), no la regla que falló.
+
+## Perfiles por versión de Odoo — `Profile`
+
+`get_profile("17.0")` describe lo que es fijo para cada versión soportada
+(15.0–19.0). Las imágenes `odoo:` abarcan **tres bases distintas con tres
+versiones de pip**, que es la razón por la que un flag de pip puede funcionar
+en una y romper en otra (issue #152):
+
+| Odoo | Base | pip | `--break-system-packages` |
+|---|---|---|---|
+| 15.0, 16.0 | debian-bullseye | 20.3 | no |
+| 17.0 | ubuntu-jammy | 22.0 | no |
+| 18.0, 19.0 | ubuntu-noble | 24.0 | sí |
+
+Cualquier código que genere un Dockerfile debería consultar el perfil en vez de
+asumir una base.

--- a/rocketdoo/core/models/__init__.py
+++ b/rocketdoo/core/models/__init__.py
@@ -1,0 +1,47 @@
+"""Shared domain models.
+
+One definition of each config schema, used by the CLI, the GUI/API and the
+deployers alike. Before these existed the GUI and the deployers disagreed on
+the shape of `.rkd/instance.yaml`, and anything the GUI wrote could not be
+deployed.
+"""
+
+from rocketdoo.core.models.deploy import (
+    DeployConfig,
+    DeploymentResult,
+    DeployTarget,
+    ModulesConfig,
+    OdooSHConfig,
+    TargetConnection,
+)
+from rocketdoo.core.models.instance import (
+    InstanceConfig,
+    InstanceEnvironment,
+    VPSConnection,
+)
+from rocketdoo.core.models.project import (
+    PROFILES,
+    SUPPORTED_ODOO_VERSIONS,
+    Profile,
+    ProjectConfig,
+    ProjectPorts,
+    get_profile,
+)
+
+__all__ = [
+    "PROFILES",
+    "SUPPORTED_ODOO_VERSIONS",
+    "DeployConfig",
+    "DeployTarget",
+    "DeploymentResult",
+    "InstanceConfig",
+    "InstanceEnvironment",
+    "ModulesConfig",
+    "OdooSHConfig",
+    "Profile",
+    "ProjectConfig",
+    "ProjectPorts",
+    "TargetConnection",
+    "VPSConnection",
+    "get_profile",
+]

--- a/rocketdoo/core/models/deploy.py
+++ b/rocketdoo/core/models/deploy.py
@@ -1,0 +1,126 @@
+"""Domain models for `.rkd/deploy.yaml` and deployment outcomes.
+
+The deploy.yaml schema was described in two places that had drifted: the
+validator in core/deploy/config_manager.py and the template under
+templates/deploy/. These models are the single definition, and they produce
+messages that name the field rather than the rule that failed.
+"""
+
+from datetime import datetime
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+TargetType = Literal["vps", "odoo-sh"]
+DeploymentType = Literal["docker", "native"]
+
+
+class TargetConnection(BaseModel):
+    """SSH details for a VPS target."""
+
+    model_config = ConfigDict(extra="allow")
+
+    host: str = ""
+    user: str = ""
+    port: int = 22
+    ssh_key: str = ""
+    # Literal, or a "${VAR}" reference resolved at deploy time.
+    password: str = ""
+
+    @model_validator(mode="after")
+    def _one_credential_only(self) -> "TargetConnection":
+        if self.ssh_key and self.password:
+            raise ValueError("connection defines both ssh_key and password; use one")
+        return self
+
+
+class OdooSHConfig(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    project_id: str = ""
+    branch: str = ""
+
+
+class DeployTarget(BaseModel):
+    """One entry under `targets:` in deploy.yaml."""
+
+    model_config = ConfigDict(extra="allow")
+
+    type: TargetType
+    connection: TargetConnection | None = None
+    deployment_type: DeploymentType | None = None
+    odoo_sh: OdooSHConfig | None = None
+
+    def validation_errors(self, name: str) -> list[str]:
+        """Human-readable problems with this target, named by field.
+
+        Mirrors what DeployConfigManager.validate() reported, so existing
+        messages keep their shape.
+        """
+        errors: list[str] = []
+        if self.type == "vps":
+            if self.connection is None:
+                errors.append(f"Target '{name}': missing 'connection' section")
+            else:
+                for field in ("host", "user"):
+                    if not getattr(self.connection, field):
+                        errors.append(f"Target '{name}': missing connection.{field}")
+            if self.deployment_type is None:
+                errors.append(f"Target '{name}': missing 'deployment_type'")
+        elif self.type == "odoo-sh":
+            if self.odoo_sh is None:
+                errors.append(f"Target '{name}': missing 'odoo_sh' section")
+            else:
+                for field in ("project_id", "branch"):
+                    if not getattr(self.odoo_sh, field):
+                        errors.append(f"Target '{name}': missing odoo_sh.{field}")
+        return errors
+
+
+class ModulesConfig(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    auto_detect: bool = True
+    base_path: str = "addons"
+    exclude_patterns: list[str] = Field(default_factory=list)
+
+
+class DeployConfig(BaseModel):
+    """The whole deploy.yaml."""
+
+    model_config = ConfigDict(extra="allow")
+
+    modules: ModulesConfig | None = None
+    targets: dict[str, DeployTarget] = Field(default_factory=dict)
+
+    def validation_errors(self) -> list[str]:
+        errors: list[str] = []
+        if self.modules is None:
+            errors.append("Missing 'modules' section")
+        if not self.targets:
+            errors.append("No deployment targets configured")
+        for name, target in self.targets.items():
+            errors.extend(target.validation_errors(name))
+        return errors
+
+
+class DeploymentResult(BaseModel):
+    """Outcome of a deployment step.
+
+    Was a plain class in core/deploy/base.py; kept truthy and printable so the
+    existing `if result:` and `print(result)` call sites behave the same.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    success: bool
+    message: str
+    details: dict[str, Any] = Field(default_factory=dict)
+    timestamp: datetime = Field(default_factory=datetime.now)
+
+    def __bool__(self) -> bool:
+        return self.success
+
+    def __str__(self) -> str:
+        status = "✅ SUCCESS" if self.success else "❌ FAILED"
+        return f"{status}: {self.message}"

--- a/rocketdoo/core/models/instance.py
+++ b/rocketdoo/core/models/instance.py
@@ -1,0 +1,178 @@
+"""Domain models for `.rkd/instance.yaml`.
+
+The CLI wizard and the GUI wrote this file with two different shapes. The
+wizard nested the connection under `vps:`; the GUI wrote those fields flat and
+renamed two of them. The deployers read the nested shape, so anything the GUI
+saved failed with `KeyError: 'vps'` at deploy time.
+
+These models are the single definition of the file. Parsing accepts both
+shapes so existing projects keep working, and writing always produces the
+canonical nested one.
+"""
+
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+AuthMethod = Literal["ssh_key", "password"]
+DeploymentType = Literal["docker", "native"]
+PGProfileName = Literal["small", "medium", "large"]
+
+# Flat keys the GUI used, mapped onto the canonical names.
+_LEGACY_ALIASES = {
+    "password_ref": "password",
+    "email": "traefik_email",
+}
+
+# Keys that belong to the connection, wherever they were written.
+_VPS_KEYS = ("host", "port", "user", "auth_method", "ssh_key", "password")
+
+
+class VPSConnection(BaseModel):
+    """How to reach the server hosting an environment."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    host: str = ""
+    port: int = 22
+    user: str = "ubuntu"
+    auth_method: AuthMethod = "ssh_key"
+    ssh_key: str = ""
+    # Literal, or a "${VAR}" reference resolved at deploy time.
+    password: str = ""
+
+    @field_validator("port")
+    @classmethod
+    def _port_in_range(cls, value: int) -> int:
+        if not 1 <= value <= 65535:
+            raise ValueError(f"SSH port must be between 1 and 65535, got {value}")
+        return value
+
+    @model_validator(mode="after")
+    def _credential_matches_method(self) -> "VPSConnection":
+        """A key-based connection needs a key; a password one needs a password.
+
+        Empty is allowed while a config is still being filled in — `is_complete`
+        is what the deployer checks before connecting.
+        """
+        if self.auth_method == "ssh_key" and self.password:
+            raise ValueError("auth_method is 'ssh_key' but a password was given")
+        if self.auth_method == "password" and self.ssh_key:
+            raise ValueError("auth_method is 'password' but an ssh_key was given")
+        return self
+
+    @property
+    def is_complete(self) -> bool:
+        """Whether this connection carries enough detail to attempt a deploy."""
+        if not self.host:
+            return False
+        return bool(self.ssh_key) if self.auth_method == "ssh_key" else bool(self.password)
+
+
+class InstanceEnvironment(BaseModel):
+    """One deployment target — typically `stage` or `prod`."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    type: DeploymentType = "docker"
+    vps: VPSConnection = Field(default_factory=VPSConnection)
+
+    odoo_version: str = "17.0"
+    odoo_tag: str = ""
+    domain: str = ""
+    traefik_email: str = ""
+
+    db_version: str = "16"
+    db_user: str = "odoo"
+    admin_passwd: str = ""
+
+    use_enterprise: bool = False
+    use_gitman: bool = False
+    gitman_config: str = ""
+
+    pg_profile: PGProfileName = "small"
+    remote_path: str = ""
+
+    @model_validator(mode="before")
+    @classmethod
+    def _accept_flat_and_nested(cls, data: Any) -> Any:
+        """Normalise the GUI's flat shape into the canonical nested one.
+
+        Runs before field validation, so both of these parse identically:
+
+            {"vps": {"host": "h"}, "odoo_version": "17.0"}   # wizard
+            {"host": "h", "odoo_version": "17.0"}            # GUI
+        """
+        if not isinstance(data, dict):
+            return data
+
+        normalised = dict(data)
+
+        for legacy, canonical in _LEGACY_ALIASES.items():
+            if legacy in normalised:
+                value = normalised.pop(legacy)
+                normalised.setdefault(canonical, value)
+
+        vps = dict(normalised.get("vps") or {})
+        for key in _VPS_KEYS:
+            if key in normalised:
+                # An explicit vps: block wins over a stray flat key.
+                vps.setdefault(key, normalised.pop(key))
+            else:
+                normalised.pop(key, None)
+        normalised["vps"] = vps
+
+        return normalised
+
+    @model_validator(mode="after")
+    def _fill_derived_defaults(self) -> "InstanceEnvironment":
+        if not self.odoo_tag:
+            self.odoo_tag = self.odoo_version
+        return self
+
+    @property
+    def is_deployable(self) -> bool:
+        """Whether a deploy could be attempted with what is configured."""
+        return self.vps.is_complete and bool(self.domain)
+
+    def missing_fields(self) -> list[str]:
+        """Which required values are still empty, for actionable errors."""
+        missing = []
+        if not self.vps.host:
+            missing.append("vps.host")
+        if self.vps.auth_method == "ssh_key" and not self.vps.ssh_key:
+            missing.append("vps.ssh_key")
+        if self.vps.auth_method == "password" and not self.vps.password:
+            missing.append("vps.password")
+        if not self.domain:
+            missing.append("domain")
+        return missing
+
+
+class InstanceConfig(BaseModel):
+    """The whole `.rkd/instance.yaml`."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    environments: dict[str, InstanceEnvironment] = Field(default_factory=dict)
+
+    @model_validator(mode="before")
+    @classmethod
+    def _accept_bare_environment_map(cls, data: Any) -> Any:
+        """Accept a file that is just `{stage: {...}}`, without the wrapper key.
+
+        The GUI's own reader assumed this shape, so a file written that way
+        must not be lost.
+        """
+        if not isinstance(data, dict) or "environments" in data:
+            return data
+        if data and all(isinstance(v, dict) for v in data.values()):
+            return {"environments": data}
+        return data
+
+    def get(self, env: str) -> InstanceEnvironment | None:
+        return self.environments.get(env)
+
+    def to_yaml_dict(self) -> dict:
+        """The canonical nested shape, for writing back to disk."""
+        return self.model_dump(mode="json")

--- a/rocketdoo/core/models/project.py
+++ b/rocketdoo/core/models/project.py
@@ -1,0 +1,149 @@
+"""Domain models for a local Rocketdoo project.
+
+`ProjectConfig` describes what project_info.py reconstructs today by scraping
+the generated Dockerfile and docker-compose.yaml. `Profile` captures what is
+fixed per Odoo version, so the golden paths in #139 have something to build on
+rather than rediscovering it.
+"""
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+Edition = Literal["Community", "Enterprise"]
+
+SUPPORTED_ODOO_VERSIONS = ("15.0", "16.0", "17.0", "18.0", "19.0")
+
+
+class Profile(BaseModel):
+    """What is fixed for a given Odoo version.
+
+    `base_distro` and `pip_version` are not cosmetic: the odoo images span
+    three bases with three pip versions, which is why a pip flag can work on
+    one and break on another (issue #152). Anything generating a Dockerfile
+    needs to know which it is targeting.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    odoo_version: str
+    base_distro: str
+    pip_version: str
+    default_db_version: str
+    supports_break_system_packages: bool
+    has_pipx: bool
+
+    @property
+    def image(self) -> str:
+        return f"odoo:{self.odoo_version}"
+
+
+# pip 23 introduced --break-system-packages; the older bases predate it.
+# Removing EXTERNALLY-MANAGED works everywhere, which is what the template does.
+PROFILES: dict[str, Profile] = {
+    "15.0": Profile(
+        odoo_version="15.0",
+        base_distro="debian-bullseye",
+        pip_version="20.3",
+        default_db_version="13",
+        supports_break_system_packages=False,
+        has_pipx=False,
+    ),
+    "16.0": Profile(
+        odoo_version="16.0",
+        base_distro="debian-bullseye",
+        pip_version="20.3",
+        default_db_version="14",
+        supports_break_system_packages=False,
+        has_pipx=False,
+    ),
+    "17.0": Profile(
+        odoo_version="17.0",
+        base_distro="ubuntu-jammy",
+        pip_version="22.0",
+        default_db_version="15",
+        supports_break_system_packages=False,
+        has_pipx=True,
+    ),
+    "18.0": Profile(
+        odoo_version="18.0",
+        base_distro="ubuntu-noble",
+        pip_version="24.0",
+        default_db_version="16",
+        supports_break_system_packages=True,
+        has_pipx=True,
+    ),
+    "19.0": Profile(
+        odoo_version="19.0",
+        base_distro="ubuntu-noble",
+        pip_version="24.0",
+        default_db_version="16",
+        supports_break_system_packages=True,
+        has_pipx=True,
+    ),
+}
+
+
+def get_profile(odoo_version: str) -> Profile:
+    """The profile for an Odoo version.
+
+    Raises ValueError for an unsupported version rather than guessing: the
+    generated Dockerfile depends on getting the base image right.
+    """
+    try:
+        return PROFILES[odoo_version]
+    except KeyError:
+        supported = ", ".join(SUPPORTED_ODOO_VERSIONS)
+        raise ValueError(f"Unsupported Odoo version {odoo_version!r}. Supported: {supported}") from None
+
+
+class ProjectPorts(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    odoo: int = 8069
+    vscode: int = 8888
+
+    @field_validator("odoo", "vscode")
+    @classmethod
+    def _unprivileged(cls, value: int) -> int:
+        if not 1024 <= value <= 65535:
+            raise ValueError(f"Port must be between 1024 and 65535, got {value}")
+        return value
+
+
+class ProjectConfig(BaseModel):
+    """A generated Rocketdoo project, as read back from disk."""
+
+    model_config = ConfigDict(extra="allow")
+
+    project_name: str
+    odoo_version: str = "17.0"
+    odoo_edition: Edition = "Community"
+    db_version: str = "16"
+
+    odoo_container: str = ""
+    db_container: str = ""
+    ports: ProjectPorts = Field(default_factory=ProjectPorts)
+
+    uses_ssh: bool = False
+    ssh_key_name: str = ""
+    third_party_repos: list[str] = Field(default_factory=list)
+    restart: str = "unless-stopped"
+
+    @field_validator("project_name")
+    @classmethod
+    def _docker_requires_lowercase(cls, value: str) -> str:
+        """Docker Compose rejects uppercase project names."""
+        if value != value.lower():
+            raise ValueError(f"Project name must be lowercase, got {value!r}")
+        return value
+
+    @property
+    def profile(self) -> Profile:
+        return get_profile(self.odoo_version)
+
+    def model_post_init(self, _context) -> None:
+        if not self.odoo_container:
+            self.odoo_container = f"odoo-{self.project_name}"
+        if not self.db_container:
+            self.db_container = f"db-{self.project_name}"

--- a/rocketdoo/gui/api/deploy_ops.py
+++ b/rocketdoo/gui/api/deploy_ops.py
@@ -5,7 +5,9 @@ GUI API — Module deployment (rkd deploy group).
 from pathlib import Path
 
 from fastapi import APIRouter
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
+
+from rocketdoo.core.models import DeployConfig
 
 router = APIRouter()
 
@@ -95,9 +97,18 @@ async def deploy_init(body: DeployInitRequest):
             "validations": {"check_manifest": True, "check_python_syntax": True},
             "logging": {"level": "INFO", "file": ".rkd/deploy.log", "console": True},
         }
+        # Validate before writing: an unusable deploy.yaml saved here would
+        # only surface later, at deploy time.
+        parsed = DeployConfig.model_validate(config)
+        errors = parsed.validation_errors()
+        if errors:
+            return {"ok": False, "error": "; ".join(errors)}
+
         p.parent.mkdir(parents=True, exist_ok=True)
         p.write_text(yaml.dump(config, default_flow_style=False, sort_keys=False, allow_unicode=True))
         return {"ok": True}
+    except ValidationError as e:
+        return {"ok": False, "error": "; ".join(f"{'.'.join(str(x) for x in err['loc'])}: {err['msg']}" for err in e.errors())}
     except Exception as e:
         return {"ok": False, "error": str(e)}
 

--- a/rocketdoo/gui/api/instances.py
+++ b/rocketdoo/gui/api/instances.py
@@ -4,42 +4,55 @@ import yaml
 from fastapi import APIRouter
 from pydantic import BaseModel
 
+from rocketdoo.core.models import InstanceConfig
+
 router = APIRouter()
 
 
-def _load_instances() -> dict:
+def _load_instances() -> InstanceConfig:
+    """Read .rkd/instance.yaml, whichever shape it was written in.
+
+    Returns an empty config when the file is missing or unreadable: the GUI
+    renders "no instances configured" rather than an error page.
+    """
     cfg = Path(".rkd") / "instance.yaml"
-    if cfg.exists():
-        try:
-            return yaml.safe_load(cfg.read_text()) or {}
-        except Exception:
-            pass
-    return {}
+    if not cfg.exists():
+        return InstanceConfig()
+    try:
+        return InstanceConfig.model_validate(yaml.safe_load(cfg.read_text()) or {})
+    except Exception:
+        return InstanceConfig()
 
 
 @router.get("")
 async def list_instances():
-    data = _load_instances()
-    envs = []
-    for env_name, cfg in data.items():
-        if not isinstance(cfg, dict):
-            continue
-        envs.append(
+    config = _load_instances()
+    return {
+        "instances": [
             {
-                "env": env_name,
-                "type": cfg.get("type", "docker"),
-                "host": cfg.get("host", ""),
-                "domain": cfg.get("domain", ""),
-                "odoo_version": cfg.get("odoo_version", ""),
-                "remote_path": cfg.get("remote_path", ""),
-                "user": cfg.get("user", ""),
-                "port": cfg.get("port", 22),
+                "env": name,
+                "type": env.type,
+                "host": env.vps.host,
+                "domain": env.domain,
+                "odoo_version": env.odoo_version,
+                "remote_path": env.remote_path,
+                "user": env.vps.user,
+                "port": env.vps.port,
+                "deployable": env.is_deployable,
+                "missing": env.missing_fields(),
             }
-        )
-    return {"instances": envs}
+            for name, env in config.environments.items()
+        ]
+    }
 
 
 class EnvConfig(BaseModel):
+    """The GUI form. Field names match what the form has always posted.
+
+    InstanceEnvironment accepts this flat shape and normalises it, so the file
+    on disk ends up in the same nested form the CLI wizard writes.
+    """
+
     type: str = "docker"
     host: str = ""
     port: int = 22
@@ -48,11 +61,15 @@ class EnvConfig(BaseModel):
     ssh_key: str = ""
     password_ref: str = ""
     odoo_version: str = "17.0"
-    odoo_tag: str = "17.0"
+    odoo_tag: str = ""
     domain: str = ""
     email: str = ""
     db_user: str = "odoo"
     db_version: str = "16"
+    admin_passwd: str = ""
+    use_enterprise: bool = False
+    use_gitman: bool = False
+    gitman_config: str = ""
     pg_profile: str = "small"
     remote_path: str = ""
 
@@ -66,11 +83,27 @@ async def init_instances(body: InstanceInitRequest):
     """Save instance configuration (.rkd/instance.yaml) from GUI form data."""
     try:
         from rocketdoo.core.instance.config_manager import InstanceConfigManager
+        from rocketdoo.core.instance.secrets_store import random_password
 
-        manager = InstanceConfigManager(Path.cwd())
-        config = {"environments": {env: cfg.model_dump() for env, cfg in body.environments.items()}}
-        manager.save(config)
-        return {"ok": True, "environments": list(body.environments.keys())}
+        raw = {}
+        for env, cfg in body.environments.items():
+            values = cfg.model_dump()
+            # The wizard always sets one; without it the rendered odoo.conf
+            # would ship an empty admin_passwd.
+            if not values.get("admin_passwd"):
+                values["admin_passwd"] = random_password()
+            values.setdefault("remote_path", "")
+            if not values["remote_path"]:
+                values["remote_path"] = f"/opt/odoo-{env}"
+            raw[env] = values
+
+        config = InstanceConfig.model_validate({"environments": raw})
+        InstanceConfigManager(Path.cwd()).save(config.to_yaml_dict())
+        return {
+            "ok": True,
+            "environments": list(config.environments),
+            "incomplete": {name: env.missing_fields() for name, env in config.environments.items() if not env.is_deployable},
+        }
     except Exception as e:
         return {"ok": False, "error": str(e)}
 

--- a/tests/test_gui_api.py
+++ b/tests/test_gui_api.py
@@ -94,3 +94,84 @@ class TestServiceStatusEndpoints:
 
     def test_instances_are_empty_without_config(self, client):
         assert client.get("/api/instances").json()["instances"] == []
+
+
+class TestInstancesRoundTrip:
+    """The GUI must be able to save a config its own reader and the deployers accept.
+
+    Before #138 this round trip was broken in both directions: the GUI wrote
+    the connection flat while the deployers read it nested (`KeyError: 'vps'`),
+    and the listing endpoint did not descend into `environments`, so it showed
+    a phantom instance literally named "environments".
+    """
+
+    PAYLOAD = {
+        "environments": {
+            "stage": {
+                "type": "docker",
+                "host": "vps.example.com",
+                "user": "ubuntu",
+                "ssh_key": "~/.ssh/id_ed25519",
+                "odoo_version": "17.0",
+                "domain": "stage.example.com",
+                "email": "ops@example.com",
+            }
+        }
+    }
+
+    def test_saving_reports_success(self, client):
+        assert client.post("/api/instances/init", json=self.PAYLOAD).json()["ok"] is True
+
+    def test_the_saved_file_is_in_the_canonical_nested_shape(self, client, project_dir):
+        import yaml
+
+        client.post("/api/instances/init", json=self.PAYLOAD)
+        saved = yaml.safe_load((project_dir / ".rkd" / "instance.yaml").read_text())
+        stage = saved["environments"]["stage"]
+        assert stage["vps"]["host"] == "vps.example.com"
+        assert "host" not in stage
+
+    def test_the_gui_can_read_back_what_it_saved(self, client):
+        client.post("/api/instances/init", json=self.PAYLOAD)
+        instances = client.get("/api/instances").json()["instances"]
+        assert [i["env"] for i in instances] == ["stage"]
+        assert instances[0]["host"] == "vps.example.com"
+
+    def test_no_phantom_environments_entry(self, client):
+        client.post("/api/instances/init", json=self.PAYLOAD)
+        names = [i["env"] for i in client.get("/api/instances").json()["instances"]]
+        assert "environments" not in names
+
+    def test_the_gui_field_names_are_translated(self, client, project_dir):
+        import yaml
+
+        client.post("/api/instances/init", json=self.PAYLOAD)
+        stage = yaml.safe_load((project_dir / ".rkd" / "instance.yaml").read_text())["environments"]["stage"]
+        assert stage["traefik_email"] == "ops@example.com"
+
+    def test_an_admin_password_is_always_written(self, client, project_dir):
+        """The GUI form does not ask for one; odoo.conf still needs it."""
+        import yaml
+
+        client.post("/api/instances/init", json=self.PAYLOAD)
+        stage = yaml.safe_load((project_dir / ".rkd" / "instance.yaml").read_text())["environments"]["stage"]
+        assert stage["admin_passwd"]
+
+    def test_the_deployer_accepts_the_saved_config(self, client, project_dir):
+        """The end of the round trip: this used to raise KeyError: 'vps'."""
+        from rocketdoo.core.instance.config_manager import InstanceConfigManager
+        from rocketdoo.core.instance.deployer_docker import DockerInstanceDeployer
+
+        client.post("/api/instances/init", json=self.PAYLOAD)
+        env_cfg = InstanceConfigManager(project_dir).get_env("stage")
+        deployer = DockerInstanceDeployer("stage", env_cfg, project_dir)
+        assert deployer.host == "vps.example.com"
+
+    def test_an_incomplete_environment_is_reported_not_silently_saved(self, client):
+        response = client.post(
+            "/api/instances/init",
+            json={"environments": {"stage": {"type": "docker", "host": ""}}},
+        )
+        body = response.json()
+        assert body["ok"] is True
+        assert "vps.host" in body["incomplete"]["stage"]

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,288 @@
+"""Tests for the shared domain models.
+
+The models exist because the CLI and the GUI disagreed on the shape of
+`.rkd/instance.yaml`: the wizard nested the connection under `vps:`, the GUI
+wrote those fields flat, and the deployers — which read the nested shape —
+failed with `KeyError: 'vps'` on anything the GUI saved.
+
+The round-trip tests below are the contract: whichever shape comes in, the
+canonical nested shape goes out.
+"""
+
+import pytest
+import yaml
+from pydantic import ValidationError
+
+from rocketdoo.core.models import (
+    PROFILES,
+    SUPPORTED_ODOO_VERSIONS,
+    DeployConfig,
+    DeploymentResult,
+    InstanceConfig,
+    InstanceEnvironment,
+    ProjectConfig,
+    VPSConnection,
+    get_profile,
+)
+
+# The two shapes found in the wild, describing the same environment.
+NESTED = {
+    "type": "docker",
+    "vps": {
+        "host": "vps.example.com",
+        "port": 22,
+        "user": "ubuntu",
+        "auth_method": "ssh_key",
+        "ssh_key": "~/.ssh/id_ed25519",
+    },
+    "odoo_version": "17.0",
+    "domain": "stage.example.com",
+    "traefik_email": "ops@example.com",
+    "pg_profile": "small",
+    "remote_path": "/opt/odoo-stage",
+}
+
+FLAT = {
+    "type": "docker",
+    "host": "vps.example.com",
+    "port": 22,
+    "user": "ubuntu",
+    "auth_method": "ssh_key",
+    "ssh_key": "~/.ssh/id_ed25519",
+    "odoo_version": "17.0",
+    "domain": "stage.example.com",
+    "email": "ops@example.com",  # the GUI's name for traefik_email
+    "pg_profile": "small",
+    "remote_path": "/opt/odoo-stage",
+}
+
+
+class TestInstanceEnvironmentTolerantReader:
+    @pytest.mark.parametrize("raw", [NESTED, FLAT], ids=["nested", "flat"])
+    def test_both_shapes_parse(self, raw):
+        env = InstanceEnvironment.model_validate(raw)
+        assert env.vps.host == "vps.example.com"
+        assert env.vps.ssh_key == "~/.ssh/id_ed25519"
+        assert env.traefik_email == "ops@example.com"
+
+    def test_both_shapes_produce_the_same_model(self):
+        assert InstanceEnvironment.model_validate(NESTED) == InstanceEnvironment.model_validate(FLAT)
+
+    def test_output_is_always_nested(self):
+        """The deployers read env_config['vps']; that must always exist."""
+        dumped = InstanceEnvironment.model_validate(FLAT).model_dump()
+        assert "vps" in dumped
+        assert dumped["vps"]["host"] == "vps.example.com"
+        assert "host" not in dumped
+
+    def test_the_gui_password_alias_is_accepted(self):
+        env = InstanceEnvironment.model_validate(
+            {"auth_method": "password", "password_ref": "${INSTANCE_STAGE_PASSWORD}", "host": "h"}
+        )
+        assert env.vps.password == "${INSTANCE_STAGE_PASSWORD}"
+
+    def test_an_explicit_vps_block_wins_over_a_stray_flat_key(self):
+        env = InstanceEnvironment.model_validate({"vps": {"host": "nested.example.com"}, "host": "flat.example.com"})
+        assert env.vps.host == "nested.example.com"
+
+    def test_odoo_tag_defaults_to_the_version(self):
+        assert InstanceEnvironment.model_validate({"odoo_version": "18.0"}).odoo_tag == "18.0"
+
+    def test_an_explicit_odoo_tag_is_kept(self):
+        env = InstanceEnvironment.model_validate({"odoo_version": "18.0", "odoo_tag": "18.0-custom"})
+        assert env.odoo_tag == "18.0-custom"
+
+
+class TestInstanceEnvironmentValidation:
+    def test_rejects_an_unknown_deployment_type(self):
+        with pytest.raises(ValidationError):
+            InstanceEnvironment.model_validate({"type": "kubernetes"})
+
+    def test_rejects_an_unknown_pg_profile(self):
+        with pytest.raises(ValidationError):
+            InstanceEnvironment.model_validate({"pg_profile": "enormous"})
+
+    def test_rejects_an_unknown_field(self):
+        """A typo should fail loudly rather than being silently ignored."""
+        with pytest.raises(ValidationError):
+            InstanceEnvironment.model_validate({"odoo_verison": "17.0"})
+
+    @pytest.mark.parametrize("port", [0, 70000, -1])
+    def test_rejects_an_out_of_range_port(self, port):
+        with pytest.raises(ValidationError):
+            VPSConnection(port=port)
+
+    def test_rejects_a_password_on_a_key_based_connection(self):
+        with pytest.raises(ValidationError, match="ssh_key"):
+            VPSConnection(auth_method="ssh_key", password="hunter2")
+
+    def test_rejects_a_key_on_a_password_connection(self):
+        with pytest.raises(ValidationError, match="password"):
+            VPSConnection(auth_method="password", ssh_key="~/.ssh/id_rsa")
+
+
+class TestDeployability:
+    def test_a_complete_environment_is_deployable(self):
+        assert InstanceEnvironment.model_validate(NESTED).is_deployable is True
+
+    def test_missing_fields_are_named(self):
+        env = InstanceEnvironment.model_validate({"type": "docker"})
+        assert set(env.missing_fields()) == {"vps.host", "vps.ssh_key", "domain"}
+
+    def test_a_password_environment_needs_a_password_not_a_key(self):
+        env = InstanceEnvironment.model_validate({"host": "h", "domain": "d", "auth_method": "password"})
+        assert env.missing_fields() == ["vps.password"]
+
+
+class TestInstanceConfigRoundTrip:
+    def test_yaml_round_trip_is_stable(self, tmp_path):
+        """Writing and re-reading must not change the config."""
+        config = InstanceConfig.model_validate({"environments": {"stage": NESTED}})
+        path = tmp_path / "instance.yaml"
+        path.write_text(yaml.dump(config.to_yaml_dict()))
+
+        reloaded = InstanceConfig.model_validate(yaml.safe_load(path.read_text()))
+        assert reloaded == config
+
+    def test_a_flat_file_converges_on_the_canonical_shape(self, tmp_path):
+        """A file written by the old GUI is readable and re-saved nested."""
+        path = tmp_path / "instance.yaml"
+        path.write_text(yaml.dump({"environments": {"stage": FLAT}}))
+
+        config = InstanceConfig.model_validate(yaml.safe_load(path.read_text()))
+        path.write_text(yaml.dump(config.to_yaml_dict()))
+
+        rewritten = yaml.safe_load(path.read_text())
+        assert "vps" in rewritten["environments"]["stage"]
+        assert InstanceConfig.model_validate(rewritten) == config
+
+    def test_accepts_a_file_without_the_environments_wrapper(self):
+        config = InstanceConfig.model_validate({"stage": NESTED})
+        assert config.get("stage").vps.host == "vps.example.com"
+
+    def test_empty_config_has_no_environments(self):
+        assert InstanceConfig.model_validate({}).environments == {}
+
+    def test_get_returns_none_for_an_unknown_environment(self):
+        assert InstanceConfig.model_validate({"environments": {}}).get("prod") is None
+
+
+class TestDeployConfig:
+    VPS_TARGET = {
+        "type": "vps",
+        "deployment_type": "docker",
+        "connection": {"host": "h", "user": "u"},
+    }
+
+    def test_a_complete_config_validates(self):
+        config = DeployConfig.model_validate({"modules": {}, "targets": {"prod": self.VPS_TARGET}})
+        assert config.validation_errors() == []
+
+    def test_reports_a_missing_modules_section(self):
+        config = DeployConfig.model_validate({"targets": {"prod": self.VPS_TARGET}})
+        assert any("modules" in e for e in config.validation_errors())
+
+    def test_reports_no_targets(self):
+        config = DeployConfig.model_validate({"modules": {}, "targets": {}})
+        assert any("target" in e.lower() for e in config.validation_errors())
+
+    def test_errors_name_the_target_and_the_field(self):
+        config = DeployConfig.model_validate({"modules": {}, "targets": {"prod": {"type": "vps"}}})
+        errors = config.validation_errors()
+        assert any("prod" in e and "connection" in e for e in errors)
+        assert any("prod" in e and "deployment_type" in e for e in errors)
+
+    def test_rejects_both_credentials_on_one_connection(self):
+        with pytest.raises(ValidationError):
+            DeployConfig.model_validate(
+                {
+                    "targets": {
+                        "prod": {
+                            "type": "vps",
+                            "deployment_type": "docker",
+                            "connection": {"host": "h", "user": "u", "ssh_key": "k", "password": "p"},
+                        }
+                    }
+                }
+            )
+
+    def test_yaml_round_trip(self, tmp_path):
+        config = DeployConfig.model_validate({"modules": {}, "targets": {"prod": self.VPS_TARGET}})
+        path = tmp_path / "deploy.yaml"
+        path.write_text(yaml.dump(config.model_dump(mode="json")))
+        assert DeployConfig.model_validate(yaml.safe_load(path.read_text())) == config
+
+
+class TestDeploymentResult:
+    def test_is_truthy_on_success(self):
+        assert bool(DeploymentResult(success=True, message="ok")) is True
+
+    def test_is_falsy_on_failure(self):
+        assert bool(DeploymentResult(success=False, message="no")) is False
+
+    def test_prints_a_status_prefix(self):
+        assert "SUCCESS" in str(DeploymentResult(success=True, message="ok"))
+        assert "FAILED" in str(DeploymentResult(success=False, message="no"))
+
+    def test_details_default_to_empty(self):
+        assert DeploymentResult(success=True, message="ok").details == {}
+
+    def test_the_deploy_package_exports_the_same_class(self):
+        """core/deploy/base.py re-exports it; both must be the same symbol."""
+        from rocketdoo.core.deploy.base import DeploymentResult as FromBase
+
+        assert FromBase is DeploymentResult
+
+
+class TestProfiles:
+    @pytest.mark.parametrize("version", SUPPORTED_ODOO_VERSIONS)
+    def test_every_supported_version_has_a_profile(self, version):
+        assert get_profile(version).odoo_version == version
+
+    def test_an_unsupported_version_raises_with_the_supported_list(self):
+        with pytest.raises(ValueError, match="19.0"):
+            get_profile("13.0")
+
+    def test_image_name(self):
+        assert get_profile("17.0").image == "odoo:17.0"
+
+    @pytest.mark.parametrize("version", ["15.0", "16.0", "17.0"])
+    def test_older_images_cannot_use_break_system_packages(self, version):
+        """The pip flag that broke the build in #152 (pip < 23)."""
+        assert PROFILES[version].supports_break_system_packages is False
+
+    @pytest.mark.parametrize("version", ["18.0", "19.0"])
+    def test_newer_images_support_break_system_packages(self, version):
+        assert PROFILES[version].supports_break_system_packages is True
+
+    def test_the_profiles_span_three_distinct_bases(self):
+        """One build target would not have caught #152."""
+        assert len({p.base_distro for p in PROFILES.values()}) == 3
+
+    def test_profiles_are_immutable(self):
+        with pytest.raises(ValidationError):
+            get_profile("17.0").odoo_version = "18.0"
+
+
+class TestProjectConfig:
+    def test_container_names_derive_from_the_project(self):
+        config = ProjectConfig(project_name="demo")
+        assert config.odoo_container == "odoo-demo"
+        assert config.db_container == "db-demo"
+
+    def test_explicit_container_names_are_kept(self):
+        config = ProjectConfig(project_name="demo", odoo_container="custom")
+        assert config.odoo_container == "custom"
+
+    def test_rejects_an_uppercase_project_name(self):
+        """Docker Compose rejects these, so `rkd init` lowercases them."""
+        with pytest.raises(ValidationError, match="lowercase"):
+            ProjectConfig(project_name="MyProject")
+
+    def test_exposes_the_profile_for_its_version(self):
+        assert ProjectConfig(project_name="demo", odoo_version="15.0").profile.base_distro == "debian-bullseye"
+
+    @pytest.mark.parametrize("port", [80, 70000])
+    def test_rejects_privileged_or_out_of_range_ports(self, port):
+        with pytest.raises(ValidationError):
+            ProjectConfig(project_name="demo", ports={"odoo": port})


### PR DESCRIPTION
Tercera épica del roadmap IDP (E3). Modelos Pydantic como contrato único entre
CLI, GUI/API y deployers.

**530 tests** (desde 442). Los formatos en disco no cambian: el lector es tolerante.

## El bug principal, verificado end-to-end

La GUI escribía la conexión con campos **planos**; los deployers leen `env_config["vps"]` (**anidado**). Todo `.rkd/instance.yaml` guardado desde la GUI fallaba al desplegar:

```
KeyError: 'vps'
```

Y no era el único desacuerdo:

| Campo | GUI escribía | CLI/deployer espera |
|---|---|---|
| conexión | plana en el entorno | anidada bajo `vps:` |
| password | `password_ref` | `password` |
| email Let's Encrypt | `email` | `traefik_email` |
| `admin_passwd` | **nunca lo escribía** | requerido por `odoo.conf` |

Sin `admin_passwd`, el `odoo.conf` renderizado salía **sin master password**.

## Un tercer bug que no estaba documentado

`list_instances()` no descendía a la clave `environments`, así que **la GUI no podía releer lo que ella misma había guardado**. Listaba una instancia fantasma llamada literalmente `"environments"`, con todos los campos vacíos:

```json
{"instances": [{"env": "environments", "host": "", "domain": "", "port": 22}]}
```

## La solución

`InstanceEnvironment` acepta las **tres formas que existen en disco** y siempre escribe la canónica, así que los proyectos existentes siguen funcionando y convergen al guardarse:

| Forma | Origen |
|---|---|
| Conexión anidada bajo `vps:` | wizard `rkd instance init` |
| Campos de conexión planos | GUI anterior a v3.2 |
| Sin la clave `environments:` | lector de la GUI anterior a v3.2 |

Los campos desconocidos ahora se rechazan: un `odoo_verison` mal escrito falla al validar en vez de ignorarse en silencio.

## Resto de los modelos

- **`DeployConfig`** — `deploy.yaml` valida con el modelo. Los mensajes siguen nombrando el campo (`Target 'production': missing connection.host`) y ahora se detecta un `type` inválido, que antes se guardaba en silencio.
- **`/api/deploy/init`** valida antes de escribir, en vez de guardar un config inusable que sólo fallaba al desplegar.
- **`DeploymentResult`** pasa a `core/models`. Los 30 call sites ya usaban keywords, así que el cambio a `BaseModel` es transparente; sigue siendo truthy e imprimible.
- **`Profile`** codifica la matriz de #152 — tres bases con tres versiones de pip — lista para los golden paths de #139:

  | Odoo | Base | pip | `--break-system-packages` |
  |---|---|---|---|
  | 15.0, 16.0 | debian-bullseye | 20.3 | no |
  | 17.0 | ubuntu-jammy | 22.0 | no |
  | 18.0, 19.0 | ubuntu-noble | 24.0 | sí |

## Tests (+88)

`test_models.py` cubre el lector tolerante, la validación y el round-trip YAML↔modelo de cada esquema. `test_gui_api.py` suma el round trip completo: la GUI guarda → la GUI relee → **el deployer lo consume**, que es exactamente lo que estaba roto.

## Nota sobre un criterio

La issue pedía los modelos "extendiendo `OdooModule`". No lo hice: `OdooModule` ya cubre su dominio (leer `__manifest__.py`) y tiene su propia suite; envolverlo en Pydantic sería churn sin ganancia. Los modelos nuevos cubren los esquemas de configuración, que es donde estaba la divergencia.

## Cómo probarlo

```bash
pip install -e . -r requirements-dev.txt
pytest                    # 530 pasan
rkd gui                   # guardar una instancia y verla listada
rkd instance status       # el CLI lee lo que guardó la GUI
```

Esquemas documentados en `rocketdoo/core/models/README.md`.

Refs #138
