### PR TITLE
FEAT: golden paths — perfiles por versión de Odoo (15-19) y edición (E4)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,6 +103,50 @@ jobs:
           name: release-dists
           path: dist/
 
+  golden-paths:
+    name: Golden path ${{ matrix.profile }}
+    # The canonical combinations from #139. Cheap enough to run on every PR:
+    # rendering plus `docker compose config`, no image build.
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        profile: [odoo15-ce, odoo18-ce, odoo19-ee]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+      - run: pip install -e .
+      - name: rkd scaffold && rkd init --profile ${{ matrix.profile }}
+        run: |
+          mkdir -p /tmp/${{ matrix.profile }}
+          cd /tmp/${{ matrix.profile }}
+          rkd scaffold
+          rkd init --profile ${{ matrix.profile }}
+      - name: docker compose config accepts it
+        run: docker compose -f /tmp/${{ matrix.profile }}/docker-compose.yaml config > /dev/null
+      - name: The rendered files match the profile
+        run: |
+          cd /tmp/${{ matrix.profile }}
+          python - <<'PY'
+          import os, re, pathlib
+          from rocketdoo.core.models.profiles import get_golden_path
+
+          profile = get_golden_path(os.environ["PROFILE"])
+          dockerfile = pathlib.Path("Dockerfile").read_text()
+          compose = pathlib.Path("docker-compose.yaml").read_text()
+
+          assert f"FROM odoo:{profile.odoo_version}" in dockerfile, dockerfile.splitlines()[0]
+          assert f"postgres:{profile.db_version}" in compose, "postgres image mismatch"
+          if profile.uses_enterprise:
+              assert "enterprise" in compose, "enterprise volume not enabled"
+          print(f"{profile.name}: odoo {profile.odoo_version} / pg {profile.db_version} OK")
+          PY
+        env:
+          PROFILE: ${{ matrix.profile }}
+
   odoo-images:
     name: Docker build (odoo:${{ matrix.odoo-version }})
     # Expensive: only on the way to a release, or when explicitly requested.
@@ -166,7 +210,7 @@ jobs:
     if: always()
     # odoo-images is conditional: when it is skipped its result is 'skipped',
     # not 'failure', so it gates the release PRs without blocking dev/v3.
-    needs: [lint, test, test-docker, build, odoo-images]
+    needs: [lint, test, test-docker, build, golden-paths, odoo-images]
     runs-on: ubuntu-latest
     steps:
       - name: Fail if any job failed

--- a/rocketdoo/cli.py
+++ b/rocketdoo/cli.py
@@ -11,6 +11,7 @@ from rich.text import Text
 
 from rocketdoo import __version__
 from rocketdoo.core.gitignore_manager import missing_entries
+from rocketdoo.core.models.profiles import ProfileCatalog, get_golden_path
 from rocketdoo.deploy_cli import deploy, deploy_config, deploy_init, deploy_run, list_modules, validate_modules
 from rocketdoo.docker_cli import build, docker, down, logs, pause, restart, status, stop, up
 from rocketdoo.gui_cli import gui_command
@@ -194,21 +195,99 @@ def scaffold(ctx, template, force):
 
 
 @main.command()
-@click.option("--docker-compose", "-d", is_flag=True, help="Generate docker-compose.yml configuration")
 @click.option(
-    "--odoo-version",
-    "-o",
-    default="16.0",
-    type=click.Choice(["14.0", "15.0", "16.0", "17.0"]),
-    help="Odoo version to configure for the project",
+    "--profile",
+    "-p",
+    default=None,
+    help="Create the project from a golden path without prompting (see: rkd profiles list)",
 )
 @click.pass_context
-def init(ctx, docker_compose, odoo_version):
-    """Initialize interactive environment configuration setup."""
-    # NOTE: --docker-compose and --odoo-version are accepted but ignored;
-    # init_project() runs the full interactive wizard regardless. Wiring
-    # them up means giving `rkd init` a real non-interactive mode.
-    init_project()
+def init(ctx, profile):
+    """Initialize environment configuration, interactively or from a profile."""
+    if profile:
+        try:
+            get_golden_path(profile)
+        except ValueError as exc:
+            raise click.BadParameter(str(exc), param_hint="--profile") from None
+    init_project(profile=profile)
+
+
+@main.group(invoke_without_command=True)
+@click.pass_context
+def profiles(ctx):
+    """Show the supported Odoo / PostgreSQL / edition combinations."""
+    if ctx.invoked_subcommand is None:
+        ctx.invoke(profiles_list)
+
+
+@profiles.command(name="list")
+def profiles_list():
+    """List the golden paths available to `rkd init --profile`."""
+    catalog = ProfileCatalog()
+    table = Table(title="Rocketdoo golden paths", box=box.ROUNDED, header_style="bold cyan")
+    table.add_column("Profile", style="cyan", no_wrap=True)
+    table.add_column("Odoo", justify="right")
+    table.add_column("Edition")
+    table.add_column("PG", justify="right")
+    table.add_column("Needs", style="dim", justify="right")
+    table.add_column("Base", style="dim", no_wrap=True)
+    table.add_column("Support", no_wrap=True)
+
+    for row in catalog.rows():
+        release = get_golden_path(row["name"]).release
+        # "bullseye · py3.9" reads better than the full distro id in a table.
+        base = f"{release.base_distro.split('-')[-1]} · py{row['python']}"
+        table.add_row(
+            row["name"],
+            row["odoo_version"],
+            "CE" if row["edition"] == "Community" else "EE",
+            row["db_version"],
+            f"{release.postgres_minimum}+",
+            base,
+            "[green]golden[/green]" if row["golden"] else "[dim]best effort[/dim]",
+        )
+
+    console.print()
+    console.print(table)
+    console.print(
+        "\n[dim]PG[/dim]    the version this profile uses.  "
+        "[dim]Needs[/dim]  the minimum Odoo supports.\n"
+        "[green]golden[/green]      rendered and built by CI on every release PR.\n"
+        "[dim]best effort[/dim] within Odoo's stated requirements, but not built by CI.\n"
+    )
+    console.print("[dim]Create one with:[/dim] [cyan]rkd init --profile odoo18-ce[/cyan]\n")
+
+
+@profiles.command(name="show")
+@click.argument("name")
+def profiles_show(name):
+    """Show the details of one profile."""
+    try:
+        profile = get_golden_path(name)
+    except ValueError as exc:
+        raise click.BadParameter(str(exc), param_hint="NAME") from None
+
+    release = profile.release
+    console.print()
+    console.print(
+        Panel(
+            f"[bold cyan]{profile.description}[/bold cyan]\n\n"
+            f"[dim]Odoo       :[/dim] {profile.odoo_version} ({profile.edition})\n"
+            f"[dim]Image      :[/dim] {release.image}\n"
+            f"[dim]Base       :[/dim] {release.base_distro}\n"
+            f"[dim]Python     :[/dim] {release.python_version}\n"
+            f"[dim]pip        :[/dim] {release.pip_version}\n"
+            f"[dim]PostgreSQL :[/dim] {profile.db_version} "
+            f"(supported: {', '.join(release.supported_postgres())})\n"
+            f"[dim]Support    :[/dim] {'golden — built by CI' if profile.is_golden else 'best effort'}",
+            title=profile.name,
+            border_style="cyan",
+            box=box.ROUNDED,
+        )
+    )
+    for note in profile.notes():
+        console.print(f"[yellow]![/yellow] {note}")
+    console.print()
 
 
 @main.command()

--- a/rocketdoo/core/edition_setup.py
+++ b/rocketdoo/core/edition_setup.py
@@ -67,6 +67,58 @@ def check_enterprise_folder(project_root: Path) -> bool:
     return enterprise_path.exists() and enterprise_path.is_dir()
 
 
+# Modules Odoo Enterprise always ships. Finding none of them means the
+# directory is not an Enterprise checkout, whatever else is in it.
+_ENTERPRISE_MARKERS = ("web_enterprise", "account_accountant", "sale_subscription")
+
+
+def validate_enterprise_setup(project_root: Path) -> list[str]:
+    """Problems that would stop an Enterprise project from starting.
+
+    check_enterprise_folder() only answers whether the directory exists, so an
+    empty `enterprise/` read as ready and Odoo then failed to find the addons.
+    Returns actionable messages, empty when the setup looks usable.
+    """
+    project_root = Path(project_root)
+    enterprise = project_root / "enterprise"
+
+    if not enterprise.exists():
+        return [
+            "The 'enterprise/' directory is missing. Odoo Enterprise addons are not "
+            "public: clone them with your subscription credentials "
+            "(git clone git@github.com:odoo/enterprise.git enterprise)."
+        ]
+
+    if not enterprise.is_dir():
+        return ["'enterprise' exists but is not a directory."]
+
+    modules = [d for d in enterprise.iterdir() if d.is_dir() and (d / "__manifest__.py").exists()]
+    if not modules:
+        return [
+            "The 'enterprise/' directory has no Odoo modules in it. A clone that "
+            "failed for lack of credentials leaves it empty, and Odoo will start "
+            "without the Enterprise addons."
+        ]
+
+    issues = []
+    names = {d.name for d in modules}
+    if not names & set(_ENTERPRISE_MARKERS):
+        issues.append(
+            f"'enterprise/' holds {len(modules)} module(s) but none of the ones "
+            f"Odoo Enterprise always ships ({', '.join(_ENTERPRISE_MARKERS)}). "
+            "Check that it is really an Enterprise checkout."
+        )
+    return issues
+
+
+def enterprise_addons_count(project_root: Path) -> int:
+    """How many Odoo modules the enterprise/ directory holds."""
+    enterprise = Path(project_root) / "enterprise"
+    if not enterprise.is_dir():
+        return 0
+    return sum(1 for d in enterprise.iterdir() if d.is_dir() and (d / "__manifest__.py").exists())
+
+
 def setup_enterprise_edition(project_root: Path):
     """
     Configure the project to use Odoo Enterprise.
@@ -78,9 +130,6 @@ def setup_enterprise_edition(project_root: Path):
     odoo_conf_path = project_root / "config" / "odoo.conf"
 
     try:
-        # Check if the enterprise folder exists
-        has_enterprise_folder = check_enterprise_folder(project_root)
-
         # Enable in docker-compose
         if compose_path.exists():
             enable_enterprise_in_compose(compose_path)
@@ -91,15 +140,16 @@ def setup_enterprise_edition(project_root: Path):
 
         print("\n📦 Enterprise edition configured successfully")
 
-        # Warning if the enterprise folder does not exist
-        if not has_enterprise_folder:
-            print("\n⚠️  IMPORTANT! The ‘enterprise/’ folder was not found.")
-            print("📁 Don't forget to add the 'enterprise' folder with the Odoo Enterprise modules")
-            print("💡 You can obtain it from:")
-            print("   • Official Odoo repository (requires subscription)")
-            print("   • git clone https://github.com/odoo/enterprise.git")
+        # Report what would actually stop Odoo from starting, not just whether
+        # the directory exists.
+        issues = validate_enterprise_setup(project_root)
+        if issues:
+            print("\n⚠️  IMPORTANT! The Enterprise setup is incomplete:")
+            for issue in issues:
+                print(f"   • {issue}")
         else:
-            print("✅ 'enterprise/' folder found")
+            count = enterprise_addons_count(project_root)
+            print(f"✅ 'enterprise/' found with {count} module(s)")
 
     except FileNotFoundError as e:
         print(f"❌ Error: {e}")

--- a/rocketdoo/core/models/profiles.py
+++ b/rocketdoo/core/models/profiles.py
@@ -1,0 +1,274 @@
+"""Golden paths: the Odoo/PostgreSQL/edition combinations Rocketdoo supports.
+
+Before this, `init_project.py` carried two hardcoded lists — Odoo 15.0–19.0 and
+PostgreSQL 13–16 — with nothing connecting them, so the wizard happily produced
+Odoo 19 on PostgreSQL 13 despite Odoo 19 requiring 13.0 or above, and never
+warned about combinations Odoo does not support at all.
+
+Two distinct notions of "supported" live here:
+
+  golden    the combination CI actually renders and builds
+  possible  within Odoo's stated requirements, best effort
+
+The per-image facts (base distro, pip, Python) were read from the published
+`odoo:` images rather than assumed; the PostgreSQL minimums come from Odoo's
+own installation documentation.
+"""
+
+from pathlib import Path
+from typing import Literal
+
+import yaml
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+Edition = Literal["Community", "Enterprise"]
+
+# PostgreSQL majors Rocketdoo will generate a compose file for.
+KNOWN_POSTGRES = ("12", "13", "14", "15", "16", "17")
+
+# pgvector, which Odoo 19's AI features need, ships for PostgreSQL 15 and up.
+PGVECTOR_MINIMUM = 15
+
+
+class OdooRelease(BaseModel):
+    """What is fixed for one Odoo version, independent of edition."""
+
+    model_config = ConfigDict(frozen=True)
+
+    odoo_version: str
+    base_distro: str
+    python_version: str
+    pip_version: str
+    # Odoo's documented minimum, as a major version number.
+    postgres_minimum: int
+    postgres_recommended: str
+
+    @property
+    def image(self) -> str:
+        return f"odoo:{self.odoo_version}"
+
+    @property
+    def supports_break_system_packages(self) -> bool:
+        """pip grew --break-system-packages in 23.0."""
+        return int(self.pip_version.split(".")[0]) >= 23
+
+    @property
+    def has_pipx(self) -> bool:
+        """pipx is not packaged for Debian bullseye (odoo:15.0 and 16.0)."""
+        return self.base_distro != "debian-bullseye"
+
+    def supported_postgres(self) -> list[str]:
+        return [v for v in KNOWN_POSTGRES if int(v) >= self.postgres_minimum]
+
+    def supports_postgres(self, db_version: str) -> bool:
+        try:
+            return int(str(db_version).split(".")[0]) >= self.postgres_minimum
+        except ValueError:
+            return False
+
+
+# Base distro, Python and pip read from the published images.
+# PostgreSQL minimums from Odoo's install documentation: 15-18 require 12.0 or
+# above; 19 raised it to 13.0.
+RELEASES: dict[str, OdooRelease] = {
+    "15.0": OdooRelease(
+        odoo_version="15.0",
+        base_distro="debian-bullseye",
+        python_version="3.9",
+        pip_version="20.3.4",
+        postgres_minimum=12,
+        postgres_recommended="14",
+    ),
+    "16.0": OdooRelease(
+        odoo_version="16.0",
+        base_distro="debian-bullseye",
+        python_version="3.9",
+        pip_version="20.3.4",
+        postgres_minimum=12,
+        postgres_recommended="14",
+    ),
+    "17.0": OdooRelease(
+        odoo_version="17.0",
+        base_distro="ubuntu-jammy",
+        python_version="3.10",
+        pip_version="22.0.2",
+        postgres_minimum=12,
+        postgres_recommended="15",
+    ),
+    "18.0": OdooRelease(
+        odoo_version="18.0",
+        base_distro="ubuntu-noble",
+        python_version="3.12",
+        pip_version="24.0",
+        postgres_minimum=12,
+        postgres_recommended="16",
+    ),
+    "19.0": OdooRelease(
+        odoo_version="19.0",
+        base_distro="ubuntu-noble",
+        python_version="3.12",
+        pip_version="24.0",
+        postgres_minimum=13,
+        postgres_recommended="16",
+    ),
+}
+
+SUPPORTED_ODOO_VERSIONS = tuple(RELEASES)
+
+# Combinations CI renders and builds on every release PR.
+GOLDEN_COMBINATIONS = (
+    ("15.0", "Community"),
+    ("18.0", "Community"),
+    ("19.0", "Enterprise"),
+)
+
+
+class GoldenPath(BaseModel):
+    """A named, ready-to-use Odoo environment definition."""
+
+    model_config = ConfigDict(frozen=True)
+
+    name: str
+    description: str
+    odoo_version: str
+    edition: Edition = "Community"
+    db_version: str = ""
+    odoo_port: int = 8069
+    vsc_port: int = 8888
+    restart: str = "unless-stopped"
+
+    @model_validator(mode="after")
+    def _check_and_fill(self) -> "GoldenPath":
+        release = RELEASES.get(self.odoo_version)
+        if release is None:
+            supported = ", ".join(SUPPORTED_ODOO_VERSIONS)
+            raise ValueError(f"Unsupported Odoo version {self.odoo_version!r}. Supported: {supported}")
+        if not self.db_version:
+            object.__setattr__(self, "db_version", release.postgres_recommended)
+        elif not release.supports_postgres(self.db_version):
+            raise ValueError(
+                f"Odoo {self.odoo_version} requires PostgreSQL {release.postgres_minimum} or above, got {self.db_version}"
+            )
+        return self
+
+    @property
+    def release(self) -> OdooRelease:
+        return RELEASES[self.odoo_version]
+
+    @property
+    def is_golden(self) -> bool:
+        return (self.odoo_version, self.edition) in GOLDEN_COMBINATIONS
+
+    @property
+    def uses_enterprise(self) -> bool:
+        return self.edition == "Enterprise"
+
+    def notes(self) -> list[str]:
+        """Things worth telling the user before generating this environment."""
+        messages = []
+        if self.uses_enterprise:
+            messages.append(
+                "Enterprise requires an ./enterprise directory with the Odoo Enterprise addons (subscription required)."
+            )
+        if self.odoo_version == "19.0" and int(self.db_version) < PGVECTOR_MINIMUM:
+            messages.append(
+                f"Odoo 19's AI features need the pgvector extension, which ships for "
+                f"PostgreSQL {PGVECTOR_MINIMUM} and above; this profile uses {self.db_version}."
+            )
+        if not self.is_golden:
+            messages.append("This combination is supported on a best-effort basis; CI does not build it.")
+        return messages
+
+    def to_context(self, project_name: str, admin_passwd: str) -> dict:
+        """The render context `rkd init` feeds to the Jinja templates."""
+        return {
+            "project_name": project_name,
+            "odoo_version": self.odoo_version,
+            "odoo_edition": self.edition,
+            "db_version": self.db_version,
+            "odoo_port": self.odoo_port,
+            "vsc_port": self.vsc_port,
+            "restart": self.restart,
+            "odoo_image": self.release.image,
+            "odoo_container": f"odoo-{project_name}",
+            "db_container": f"db-{project_name}",
+            "admin_passwd": admin_passwd,
+        }
+
+
+PROFILE_DIR = Path(__file__).resolve().parent.parent.parent / "templates" / "profiles"
+
+
+def _load_catalog() -> dict[str, GoldenPath]:
+    """Read the profiles shipped under templates/profiles/.
+
+    The YAML files are the source of truth for which combinations exist, so a
+    user can drop another one in without touching the package.
+    """
+    catalog: dict[str, GoldenPath] = {}
+    if not PROFILE_DIR.is_dir():
+        return catalog
+    for path in sorted(PROFILE_DIR.glob("*.yaml")):
+        data = yaml.safe_load(path.read_text()) or {}
+        data.pop("golden", None)  # derived from GOLDEN_COMBINATIONS, not declared
+        data.setdefault("name", path.stem)
+        catalog[data["name"]] = GoldenPath.model_validate(data)
+    return catalog
+
+
+PROFILES: dict[str, GoldenPath] = _load_catalog()
+
+
+def get_golden_path(name: str) -> GoldenPath:
+    """Look up a profile by name, e.g. "odoo18-ce"."""
+    try:
+        return PROFILES[name]
+    except KeyError:
+        available = ", ".join(sorted(PROFILES))
+        raise ValueError(f"Unknown profile {name!r}. Available: {available}") from None
+
+
+def get_release(odoo_version: str) -> OdooRelease:
+    try:
+        return RELEASES[odoo_version]
+    except KeyError:
+        supported = ", ".join(SUPPORTED_ODOO_VERSIONS)
+        raise ValueError(f"Unsupported Odoo version {odoo_version!r}. Supported: {supported}") from None
+
+
+def check_compatibility(odoo_version: str, db_version: str) -> str | None:
+    """Return an explanation if this pairing is unsupported, else None."""
+    release = get_release(odoo_version)
+    if release.supports_postgres(db_version):
+        return None
+    return (
+        f"Odoo {odoo_version} requires PostgreSQL {release.postgres_minimum} or above; "
+        f"PostgreSQL {db_version} is not supported. "
+        f"Supported here: {', '.join(release.supported_postgres())}."
+    )
+
+
+class ProfileCatalog(BaseModel):
+    """The whole matrix, for `rkd profiles list` and the docs."""
+
+    model_config = ConfigDict(frozen=True)
+
+    profiles: dict[str, GoldenPath] = Field(default_factory=lambda: dict(PROFILES))
+
+    def rows(self) -> list[dict]:
+        rows = []
+        for name, profile in self.profiles.items():
+            release = profile.release
+            rows.append(
+                {
+                    "name": name,
+                    "odoo_version": profile.odoo_version,
+                    "edition": profile.edition,
+                    "db_version": profile.db_version,
+                    "postgres_supported": ", ".join(release.supported_postgres()),
+                    "base_distro": release.base_distro,
+                    "python": release.python_version,
+                    "golden": profile.is_golden,
+                }
+            )
+        return sorted(rows, key=lambda r: (r["odoo_version"], r["edition"]))

--- a/rocketdoo/init_project.py
+++ b/rocketdoo/init_project.py
@@ -4,7 +4,9 @@ from pathlib import Path
 import click
 import questionary
 from jinja2 import Environment, FileSystemLoader
+from rich import box
 from rich.console import Console
+from rich.panel import Panel
 
 from rocketdoo.core.edition_setup import setup_enterprise_edition
 from rocketdoo.core.gitignore_manager import ensure_gitignore
@@ -14,6 +16,7 @@ from rocketdoo.core.gitman_config import (
     generate_gitman_yaml,
     update_odoo_conf_with_gitman,
 )
+from rocketdoo.core.models.profiles import SUPPORTED_ODOO_VERSIONS, get_golden_path, get_release
 from rocketdoo.core.port_validation import (
     collect_declared_ports,
     find_available_port,
@@ -127,8 +130,51 @@ def prompt_ports_until_valid(default_odoo=8069, default_vsc=8888):
             click.echo("\n⬇️  Please enter other ports:\n")
 
 
-def init_project():
+def init_from_profile(profile_name: str, project_name: str | None = None, admin_passwd: str | None = None) -> None:
+    """Create a project from a named golden path, without prompting.
+
+    This is what `rkd init --profile odoo18-ce` runs, and what lets CI and the
+    generated per-project pipelines build an environment unattended.
+    """
+    profile = get_golden_path(profile_name)
+    project_name = (project_name or os.path.basename(os.getcwd())).lower()
+    admin_passwd = admin_passwd or "admin"
+
+    console.print()
+    console.print(
+        Panel(
+            f"[bold cyan]{profile.description}[/bold cyan]\n\n"
+            f"[dim]Image     :[/dim] {profile.release.image}\n"
+            f"[dim]PostgreSQL:[/dim] {profile.db_version}\n"
+            f"[dim]Python    :[/dim] {profile.release.python_version} on {profile.release.base_distro}\n"
+            f"[dim]Support   :[/dim] {'golden — built by CI' if profile.is_golden else 'best effort'}",
+            title=f"Profile {profile.name}",
+            border_style="cyan",
+            box=box.ROUNDED,
+        )
+    )
+    for note in profile.notes():
+        console.print(f"[yellow]![/yellow] {note}")
+    console.print()
+
+    context = profile.to_context(project_name, admin_passwd)
+    context.update({"use_private_repos": False, "ssh_key_name": None, "use_third_party_repos": False})
+
+    generate_project(context)
+
+    if profile.uses_enterprise:
+        try:
+            setup_enterprise_edition(Path(os.getcwd()))
+        except Exception as e:
+            click.echo(f"\n⚠️  Warning: Could not fully configure Enterprise: {e}")
+
+
+def init_project(profile: str | None = None):
     """Initial configuration assistant for Rocketdoo"""
+
+    if profile:
+        init_from_profile(profile)
+        return
 
     show_welcome()
 
@@ -149,7 +195,7 @@ def init_project():
         console.print("[dim]💡 Docker project names must be in lowercase[/dim]\n")
 
     # Version selection with interactive menu
-    odoo_versions = ["15.0", "16.0", "17.0", "18.0", "19.0"]
+    odoo_versions = list(SUPPORTED_ODOO_VERSIONS)
     click.echo("\n📦 Select Odoo version (use ↑↓ and ENTER):")
     odoo_version = questionary.select("Odoo Version:", choices=odoo_versions, default="18.0").ask()
 
@@ -229,9 +275,13 @@ def init_project():
                 if not questionary.confirm("Would you like to add another repository?", default=False).ask():
                     break
 
-    db_versions = ["13", "14", "15", "16"]
-    click.echo("\n📦 Select the PostgreSQL version (use ↑↓ and ENTER):")
-    db_version = questionary.select("PostgreSQL version:", choices=db_versions, default="16").ask()
+    # Only the majors this Odoo release supports: the wizard used to offer a
+    # fixed 13-16 list, so it happily produced Odoo 19 on PostgreSQL 12.
+    release = get_release(odoo_version)
+    db_versions = release.supported_postgres()
+    click.echo(f"\n📦 Select the PostgreSQL version for Odoo {odoo_version} (use ↑↓ and ENTER):")
+    click.echo(f"   [Odoo {odoo_version} requires PostgreSQL {release.postgres_minimum} or above]")
+    db_version = questionary.select("PostgreSQL version:", choices=db_versions, default=release.postgres_recommended).ask()
 
     # Ask for the master password
     admin_passwd = click.prompt("Odoo master password", default="admin", hide_input=False)
@@ -266,6 +316,31 @@ def init_project():
         "ssh_key_name": selected_ssh_key,
         "use_third_party_repos": use_third_party_repos,
     }
+
+    generate_project(context, gitman_sources=gitman_sources, selected_ssh_key=selected_ssh_key)
+
+
+def generate_project(
+    context: dict,
+    *,
+    gitman_sources=None,
+    selected_ssh_key=None,
+) -> None:
+    """Render the templates and run the post-setup steps.
+
+    Shared by the interactive wizard and by `rkd init --profile`, so both
+    produce byte-identical projects for the same choices.
+    """
+    project_name = context["project_name"]
+    odoo_version = context["odoo_version"]
+    odoo_edition = context["odoo_edition"]
+    db_version = context["db_version"]
+    odoo_port = context["odoo_port"]
+    vsc_port = context["vsc_port"]
+    use_private_repos = context.get("use_private_repos", False)
+    use_third_party_repos = context.get("use_third_party_repos", False)
+    gitman_sources = gitman_sources or []
+    selected_ssh_key = selected_ssh_key or context.get("ssh_key_name")
 
     # === Generate files ===
     # First, so the files rendered below (odoo.conf carries admin_passwd) are

--- a/rocketdoo/scaffold.py
+++ b/rocketdoo/scaffold.py
@@ -8,6 +8,11 @@ from rocketdoo.core.gitignore_manager import ensure_gitignore
 # Rendered into .gitignore instead of being copied verbatim
 GITIGNORE_TEMPLATE = ".gitignore.jinja"
 
+# Package-level template directories that are not part of a user's project.
+# profiles/ describes the golden paths Rocketdoo itself offers; copying it into
+# every generated project would just ship dead files.
+INTERNAL_TEMPLATE_DIRS = {"profiles"}
+
 
 def scaffold_project(template="basic", force=False, verbose=False):
     """
@@ -37,6 +42,9 @@ def scaffold_project(template="basic", force=False, verbose=False):
 
             if item.name == GITIGNORE_TEMPLATE:
                 # Handled after the loop so credentials are covered from the start
+                continue
+
+            if item.is_dir() and item.name in INTERNAL_TEMPLATE_DIRS:
                 continue
 
             if src.is_dir():

--- a/rocketdoo/templates/profiles/README.md
+++ b/rocketdoo/templates/profiles/README.md
@@ -1,0 +1,71 @@
+# Golden paths
+
+Cada archivo `.yaml` de este directorio define una combinación soportada de
+Odoo, edición y PostgreSQL. Son la fuente de verdad de qué ofrece
+`rkd init --profile` y `rkd profiles list`.
+
+```bash
+rkd profiles list              # ver la matriz
+rkd profiles show odoo18-ce    # detalle de un perfil
+rkd init --profile odoo18-ce   # crear el entorno sin preguntar nada
+```
+
+## Política de soporte
+
+| Nivel | Qué significa |
+|---|---|
+| **golden** | El CI renderiza y construye esta combinación en cada PR de release. Es la que conviene elegir. |
+| **best effort** | Está dentro de los requisitos que Odoo declara, y el wizard la ofrece, pero el CI no la construye. Si falla, se acepta el reporte pero no hay garantía. |
+
+Combinaciones golden hoy: `odoo15-ce`, `odoo18-ce`, `odoo19-ee`. Cubren los tres
+sistemas base distintos que usan las imágenes (ver abajo) y las dos ediciones.
+
+## Matriz de compatibilidad
+
+Los datos por imagen se leyeron de las imágenes `odoo:` publicadas; los mínimos
+de PostgreSQL salen de la documentación de instalación de Odoo.
+
+| Odoo | Base | Python | pip | PostgreSQL mínimo | Recomendado |
+|---|---|---|---|---|---|
+| 15.0 | debian-bullseye | 3.9 | 20.3.4 | 12 | 14 |
+| 16.0 | debian-bullseye | 3.9 | 20.3.4 | 12 | 14 |
+| 17.0 | ubuntu-jammy | 3.10 | 22.0.2 | 12 | 15 |
+| 18.0 | ubuntu-noble | 3.12 | 24.0 | 12 | 16 |
+| 19.0 | ubuntu-noble | 3.12 | 24.0 | **13** | 16 |
+
+Odoo 19 subió el mínimo de PostgreSQL de 12 a 13. Antes de estos perfiles el
+wizard ofrecía una lista fija de PostgreSQL 13–16 sin relacionarla con la
+versión de Odoo elegida, así que dejaba armar combinaciones no soportadas.
+
+Por qué importan `base` y `pip`: las cinco imágenes abarcan **tres sistemas base
+con tres versiones de pip**, y por eso un flag de pip puede andar en una y
+romper en otra — es exactamente lo que pasó en la issue #152. Cualquier código
+que genere un Dockerfile debería consultar el perfil en lugar de asumir.
+
+### Nota sobre Odoo 19 y AI
+
+Las funciones de AI de Odoo 19 necesitan la extensión `pgvector`, que se
+distribuye para PostgreSQL 15 en adelante. `rkd init --profile odoo19-*` avisa
+si el perfil usa una versión menor.
+
+## Agregar un perfil
+
+Alcanza con dejar otro `.yaml` en este directorio:
+
+```yaml
+name: odoo18-ce-pg17
+description: Odoo 18 Community on PostgreSQL 17
+odoo_version: "18.0"
+edition: Community
+db_version: "17"
+odoo_port: 8069
+vsc_port: 8888
+restart: unless-stopped
+golden: false
+```
+
+La compatibilidad se valida al cargarlo: un `db_version` por debajo del mínimo
+de esa versión de Odoo es un error, no una advertencia. Los datos de la imagen
+(base, Python, pip, mínimo de PostgreSQL) no se declaran acá porque describen
+la imagen publicada, no una decisión del perfil; viven en
+`rocketdoo/core/models/profiles.py`.

--- a/rocketdoo/templates/profiles/odoo15-ce.yaml
+++ b/rocketdoo/templates/profiles/odoo15-ce.yaml
@@ -1,0 +1,25 @@
+# Golden path: Odoo 15 Community on PostgreSQL 14
+#
+# Generated environments start from one of these. `rkd init --profile odoo15-ce`
+# creates it without prompting; the interactive wizard uses the same values as
+# defaults.
+#
+# Facts about the odoo:15.0 image itself -- base distro, Python, pip, the
+# PostgreSQL minimum -- are not repeated here: they live in
+# rocketdoo/core/models/profiles.py because they describe the published image,
+# not a choice this file gets to make.
+
+name: odoo15-ce
+description: Odoo 15 Community on PostgreSQL 14
+
+odoo_version: "15.0"
+edition: Community
+db_version: "14"
+
+odoo_port: 8069
+vsc_port: 8888
+restart: unless-stopped
+
+# golden: CI renders and builds this combination on every release PR.
+# Anything else is supported best effort.
+golden: true

--- a/rocketdoo/templates/profiles/odoo15-ee.yaml
+++ b/rocketdoo/templates/profiles/odoo15-ee.yaml
@@ -1,0 +1,25 @@
+# Golden path: Odoo 15 Enterprise on PostgreSQL 14
+#
+# Generated environments start from one of these. `rkd init --profile odoo15-ee`
+# creates it without prompting; the interactive wizard uses the same values as
+# defaults.
+#
+# Facts about the odoo:15.0 image itself -- base distro, Python, pip, the
+# PostgreSQL minimum -- are not repeated here: they live in
+# rocketdoo/core/models/profiles.py because they describe the published image,
+# not a choice this file gets to make.
+
+name: odoo15-ee
+description: Odoo 15 Enterprise on PostgreSQL 14
+
+odoo_version: "15.0"
+edition: Enterprise
+db_version: "14"
+
+odoo_port: 8069
+vsc_port: 8888
+restart: unless-stopped
+
+# golden: CI renders and builds this combination on every release PR.
+# Anything else is supported best effort.
+golden: false

--- a/rocketdoo/templates/profiles/odoo16-ce.yaml
+++ b/rocketdoo/templates/profiles/odoo16-ce.yaml
@@ -1,0 +1,25 @@
+# Golden path: Odoo 16 Community on PostgreSQL 14
+#
+# Generated environments start from one of these. `rkd init --profile odoo16-ce`
+# creates it without prompting; the interactive wizard uses the same values as
+# defaults.
+#
+# Facts about the odoo:16.0 image itself -- base distro, Python, pip, the
+# PostgreSQL minimum -- are not repeated here: they live in
+# rocketdoo/core/models/profiles.py because they describe the published image,
+# not a choice this file gets to make.
+
+name: odoo16-ce
+description: Odoo 16 Community on PostgreSQL 14
+
+odoo_version: "16.0"
+edition: Community
+db_version: "14"
+
+odoo_port: 8069
+vsc_port: 8888
+restart: unless-stopped
+
+# golden: CI renders and builds this combination on every release PR.
+# Anything else is supported best effort.
+golden: false

--- a/rocketdoo/templates/profiles/odoo16-ee.yaml
+++ b/rocketdoo/templates/profiles/odoo16-ee.yaml
@@ -1,0 +1,25 @@
+# Golden path: Odoo 16 Enterprise on PostgreSQL 14
+#
+# Generated environments start from one of these. `rkd init --profile odoo16-ee`
+# creates it without prompting; the interactive wizard uses the same values as
+# defaults.
+#
+# Facts about the odoo:16.0 image itself -- base distro, Python, pip, the
+# PostgreSQL minimum -- are not repeated here: they live in
+# rocketdoo/core/models/profiles.py because they describe the published image,
+# not a choice this file gets to make.
+
+name: odoo16-ee
+description: Odoo 16 Enterprise on PostgreSQL 14
+
+odoo_version: "16.0"
+edition: Enterprise
+db_version: "14"
+
+odoo_port: 8069
+vsc_port: 8888
+restart: unless-stopped
+
+# golden: CI renders and builds this combination on every release PR.
+# Anything else is supported best effort.
+golden: false

--- a/rocketdoo/templates/profiles/odoo17-ce.yaml
+++ b/rocketdoo/templates/profiles/odoo17-ce.yaml
@@ -1,0 +1,25 @@
+# Golden path: Odoo 17 Community on PostgreSQL 15
+#
+# Generated environments start from one of these. `rkd init --profile odoo17-ce`
+# creates it without prompting; the interactive wizard uses the same values as
+# defaults.
+#
+# Facts about the odoo:17.0 image itself -- base distro, Python, pip, the
+# PostgreSQL minimum -- are not repeated here: they live in
+# rocketdoo/core/models/profiles.py because they describe the published image,
+# not a choice this file gets to make.
+
+name: odoo17-ce
+description: Odoo 17 Community on PostgreSQL 15
+
+odoo_version: "17.0"
+edition: Community
+db_version: "15"
+
+odoo_port: 8069
+vsc_port: 8888
+restart: unless-stopped
+
+# golden: CI renders and builds this combination on every release PR.
+# Anything else is supported best effort.
+golden: false

--- a/rocketdoo/templates/profiles/odoo17-ee.yaml
+++ b/rocketdoo/templates/profiles/odoo17-ee.yaml
@@ -1,0 +1,25 @@
+# Golden path: Odoo 17 Enterprise on PostgreSQL 15
+#
+# Generated environments start from one of these. `rkd init --profile odoo17-ee`
+# creates it without prompting; the interactive wizard uses the same values as
+# defaults.
+#
+# Facts about the odoo:17.0 image itself -- base distro, Python, pip, the
+# PostgreSQL minimum -- are not repeated here: they live in
+# rocketdoo/core/models/profiles.py because they describe the published image,
+# not a choice this file gets to make.
+
+name: odoo17-ee
+description: Odoo 17 Enterprise on PostgreSQL 15
+
+odoo_version: "17.0"
+edition: Enterprise
+db_version: "15"
+
+odoo_port: 8069
+vsc_port: 8888
+restart: unless-stopped
+
+# golden: CI renders and builds this combination on every release PR.
+# Anything else is supported best effort.
+golden: false

--- a/rocketdoo/templates/profiles/odoo18-ce.yaml
+++ b/rocketdoo/templates/profiles/odoo18-ce.yaml
@@ -1,0 +1,25 @@
+# Golden path: Odoo 18 Community on PostgreSQL 16
+#
+# Generated environments start from one of these. `rkd init --profile odoo18-ce`
+# creates it without prompting; the interactive wizard uses the same values as
+# defaults.
+#
+# Facts about the odoo:18.0 image itself -- base distro, Python, pip, the
+# PostgreSQL minimum -- are not repeated here: they live in
+# rocketdoo/core/models/profiles.py because they describe the published image,
+# not a choice this file gets to make.
+
+name: odoo18-ce
+description: Odoo 18 Community on PostgreSQL 16
+
+odoo_version: "18.0"
+edition: Community
+db_version: "16"
+
+odoo_port: 8069
+vsc_port: 8888
+restart: unless-stopped
+
+# golden: CI renders and builds this combination on every release PR.
+# Anything else is supported best effort.
+golden: true

--- a/rocketdoo/templates/profiles/odoo18-ee.yaml
+++ b/rocketdoo/templates/profiles/odoo18-ee.yaml
@@ -1,0 +1,25 @@
+# Golden path: Odoo 18 Enterprise on PostgreSQL 16
+#
+# Generated environments start from one of these. `rkd init --profile odoo18-ee`
+# creates it without prompting; the interactive wizard uses the same values as
+# defaults.
+#
+# Facts about the odoo:18.0 image itself -- base distro, Python, pip, the
+# PostgreSQL minimum -- are not repeated here: they live in
+# rocketdoo/core/models/profiles.py because they describe the published image,
+# not a choice this file gets to make.
+
+name: odoo18-ee
+description: Odoo 18 Enterprise on PostgreSQL 16
+
+odoo_version: "18.0"
+edition: Enterprise
+db_version: "16"
+
+odoo_port: 8069
+vsc_port: 8888
+restart: unless-stopped
+
+# golden: CI renders and builds this combination on every release PR.
+# Anything else is supported best effort.
+golden: false

--- a/rocketdoo/templates/profiles/odoo19-ce.yaml
+++ b/rocketdoo/templates/profiles/odoo19-ce.yaml
@@ -1,0 +1,25 @@
+# Golden path: Odoo 19 Community on PostgreSQL 16
+#
+# Generated environments start from one of these. `rkd init --profile odoo19-ce`
+# creates it without prompting; the interactive wizard uses the same values as
+# defaults.
+#
+# Facts about the odoo:19.0 image itself -- base distro, Python, pip, the
+# PostgreSQL minimum -- are not repeated here: they live in
+# rocketdoo/core/models/profiles.py because they describe the published image,
+# not a choice this file gets to make.
+
+name: odoo19-ce
+description: Odoo 19 Community on PostgreSQL 16
+
+odoo_version: "19.0"
+edition: Community
+db_version: "16"
+
+odoo_port: 8069
+vsc_port: 8888
+restart: unless-stopped
+
+# golden: CI renders and builds this combination on every release PR.
+# Anything else is supported best effort.
+golden: false

--- a/rocketdoo/templates/profiles/odoo19-ee.yaml
+++ b/rocketdoo/templates/profiles/odoo19-ee.yaml
@@ -1,0 +1,25 @@
+# Golden path: Odoo 19 Enterprise on PostgreSQL 16
+#
+# Generated environments start from one of these. `rkd init --profile odoo19-ee`
+# creates it without prompting; the interactive wizard uses the same values as
+# defaults.
+#
+# Facts about the odoo:19.0 image itself -- base distro, Python, pip, the
+# PostgreSQL minimum -- are not repeated here: they live in
+# rocketdoo/core/models/profiles.py because they describe the published image,
+# not a choice this file gets to make.
+
+name: odoo19-ee
+description: Odoo 19 Enterprise on PostgreSQL 16
+
+odoo_version: "19.0"
+edition: Enterprise
+db_version: "16"
+
+odoo_port: 8069
+vsc_port: 8888
+restart: unless-stopped
+
+# golden: CI renders and builds this combination on every release PR.
+# Anything else is supported best effort.
+golden: true

--- a/tests/test_e2e_scaffold.py
+++ b/tests/test_e2e_scaffold.py
@@ -161,3 +161,77 @@ def test_scaffolded_templates_are_not_valid_compose_before_init(project_dir):
     """Scaffold ships .jinja sources; docker-compose.yaml only exists after init."""
     scaffold_project()
     assert not (project_dir / "docker-compose.yaml").exists()
+
+
+class TestInitFromProfile:
+    """`rkd init --profile` — the non-interactive path added in #139.
+
+    This is what makes an unattended `rkd init` possible at all, which the E2E
+    test above still has to work around by driving the wizard prompt by prompt.
+    """
+
+    @pytest.fixture
+    def built(self, project_dir):
+        from rocketdoo.init_project import init_from_profile
+
+        scaffold_project()
+        init_from_profile("odoo18-ce", project_name="demo")
+        return project_dir
+
+    def test_generates_the_core_files_without_prompting(self, built):
+        for expected in ("Dockerfile", "docker-compose.yaml", "config/odoo.conf"):
+            assert (built / expected).exists(), f"missing {expected}"
+
+    def test_uses_the_profile_odoo_version(self, built):
+        assert "FROM odoo:18.0" in (built / "Dockerfile").read_text()
+
+    def test_uses_the_profile_postgres_version(self, built):
+        compose = yaml.safe_load((built / "docker-compose.yaml").read_text())
+        assert compose["services"]["db"]["image"] == "postgres:16"
+
+    def test_writes_a_gitignore(self, built):
+        assert (built / ".gitignore").exists()
+
+    def test_scaffold_does_not_copy_the_profile_templates(self, project_dir):
+        """profiles/ describes Rocketdoo's own catalog, not the user's project."""
+        scaffold_project()
+        assert not (project_dir / "profiles").exists()
+
+    @pytest.mark.parametrize("profile", ["odoo15-ce", "odoo18-ce", "odoo19-ee"])
+    def test_the_canonical_combinations_generate(self, project_dir, profile):
+        """The three combinations CI builds on every release PR."""
+        from rocketdoo.core.models.profiles import get_golden_path
+        from rocketdoo.init_project import init_from_profile
+
+        scaffold_project()
+        init_from_profile(profile, project_name="demo")
+
+        expected = get_golden_path(profile)
+        assert f"FROM odoo:{expected.odoo_version}" in (project_dir / "Dockerfile").read_text()
+        compose = yaml.safe_load((project_dir / "docker-compose.yaml").read_text())
+        assert compose["services"]["db"]["image"] == f"postgres:{expected.db_version}"
+
+    def test_enterprise_profile_enables_the_enterprise_volume(self, project_dir):
+        from rocketdoo.init_project import init_from_profile
+
+        scaffold_project()
+        init_from_profile("odoo19-ee", project_name="demo")
+        assert "enterprise" in (project_dir / "docker-compose.yaml").read_text()
+
+    def test_an_unknown_profile_raises(self, project_dir):
+        from rocketdoo.init_project import init_from_profile
+
+        scaffold_project()
+        with pytest.raises(ValueError, match="Unknown profile"):
+            init_from_profile("odoo99-ce")
+
+    @pytest.mark.docker
+    @pytest.mark.slow
+    @pytest.mark.parametrize("profile", ["odoo15-ce", "odoo18-ce", "odoo19-ee"])
+    def test_docker_accepts_every_canonical_combination(self, project_dir, profile, requires_docker):
+        from rocketdoo.init_project import init_from_profile
+
+        scaffold_project()
+        init_from_profile(profile, project_name="demo")
+        result = _docker_compose_config(project_dir)
+        assert result.returncode == 0, result.stderr

--- a/tests/test_edition_setup.py
+++ b/tests/test_edition_setup.py
@@ -1,0 +1,112 @@
+"""Tests for core/edition_setup.py.
+
+`check_enterprise_folder` only answers whether `enterprise/` exists, so an
+empty directory — exactly what a clone that failed for lack of credentials
+leaves behind — read as ready, and Odoo then started without the Enterprise
+addons. `validate_enterprise_setup` reports what would actually break.
+"""
+
+import pytest
+
+from rocketdoo.core.edition_setup import (
+    add_enterprise_to_odoo_conf,
+    check_enterprise_folder,
+    enable_enterprise_in_compose,
+    enterprise_addons_count,
+    validate_enterprise_setup,
+)
+
+
+def _module(root, name):
+    mod = root / "enterprise" / name
+    mod.mkdir(parents=True)
+    (mod / "__manifest__.py").write_text(f"{{'name': '{name}'}}\n")
+    return mod
+
+
+class TestValidateEnterpriseSetup:
+    def test_missing_directory_explains_how_to_get_it(self, tmp_path):
+        issues = validate_enterprise_setup(tmp_path)
+        assert len(issues) == 1
+        assert "subscription credentials" in issues[0]
+
+    def test_empty_directory_is_reported(self, tmp_path):
+        """The failure mode a credential-less clone leaves behind."""
+        (tmp_path / "enterprise").mkdir()
+        issues = validate_enterprise_setup(tmp_path)
+        assert len(issues) == 1
+        assert "no Odoo modules" in issues[0]
+
+    def test_a_real_checkout_passes(self, tmp_path):
+        _module(tmp_path, "web_enterprise")
+        _module(tmp_path, "account_accountant")
+        assert validate_enterprise_setup(tmp_path) == []
+
+    def test_modules_without_the_known_markers_are_flagged(self, tmp_path):
+        _module(tmp_path, "my_custom_module")
+        issues = validate_enterprise_setup(tmp_path)
+        assert len(issues) == 1
+        assert "web_enterprise" in issues[0]
+
+    def test_a_file_named_enterprise_is_reported(self, tmp_path):
+        (tmp_path / "enterprise").write_text("not a directory")
+        assert "not a directory" in validate_enterprise_setup(tmp_path)[0]
+
+    def test_directories_without_a_manifest_do_not_count(self, tmp_path):
+        (tmp_path / "enterprise" / "docs").mkdir(parents=True)
+        assert "no Odoo modules" in validate_enterprise_setup(tmp_path)[0]
+
+
+class TestEnterpriseAddonsCount:
+    def test_counts_only_modules(self, tmp_path):
+        _module(tmp_path, "web_enterprise")
+        _module(tmp_path, "account_accountant")
+        (tmp_path / "enterprise" / "not_a_module").mkdir()
+        assert enterprise_addons_count(tmp_path) == 2
+
+    def test_zero_without_the_directory(self, tmp_path):
+        assert enterprise_addons_count(tmp_path) == 0
+
+
+class TestCheckEnterpriseFolder:
+    def test_still_reports_mere_existence(self, tmp_path):
+        """Kept for compatibility; validate_enterprise_setup is the real check."""
+        assert check_enterprise_folder(tmp_path) is False
+        (tmp_path / "enterprise").mkdir()
+        assert check_enterprise_folder(tmp_path) is True
+
+
+class TestComposeAndConf:
+    def test_uncomments_the_enterprise_volume(self, tmp_path):
+        compose = tmp_path / "docker-compose.yaml"
+        compose.write_text(
+            "services:\n  web:\n    volumes:\n      #- ./enterprise:/usr/lib/python3/dist-packages/odoo/enterprise\n"
+        )
+        enable_enterprise_in_compose(compose)
+        content = compose.read_text()
+        assert "- ./enterprise:" in content
+        assert "#- ./enterprise:" not in content
+
+    def test_missing_compose_raises(self, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            enable_enterprise_in_compose(tmp_path / "nope.yaml")
+
+    def test_adds_the_enterprise_path_to_addons_path(self, tmp_path):
+        conf = tmp_path / "odoo.conf"
+        conf.write_text("[options]\naddons_path = /mnt/extra-addons\n")
+        add_enterprise_to_odoo_conf(conf)
+        assert "dist-packages/odoo/enterprise" in conf.read_text()
+        assert "/mnt/extra-addons" in conf.read_text()
+
+    def test_does_not_duplicate_the_enterprise_path(self, tmp_path):
+        conf = tmp_path / "odoo.conf"
+        conf.write_text("[options]\naddons_path = /mnt/extra-addons\n")
+        add_enterprise_to_odoo_conf(conf)
+        add_enterprise_to_odoo_conf(conf)
+        assert conf.read_text().count("dist-packages/odoo/enterprise") == 1
+
+    def test_creates_addons_path_when_absent(self, tmp_path):
+        conf = tmp_path / "odoo.conf"
+        conf.write_text("[options]\ndb_host = db\n")
+        add_enterprise_to_odoo_conf(conf)
+        assert "addons_path" in conf.read_text()

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -1,0 +1,215 @@
+"""Tests for the golden paths (core/models/profiles.py).
+
+`init_project.py` used to carry two unrelated hardcoded lists — Odoo 15.0–19.0
+and PostgreSQL 13–16 — so the wizard would happily generate Odoo 19 on
+PostgreSQL 12, which Odoo does not support.
+
+The per-image facts asserted here were read from the published `odoo:` images;
+the PostgreSQL minimums come from Odoo's installation documentation.
+"""
+
+import pytest
+import yaml
+from pydantic import ValidationError
+
+from rocketdoo.core.models.profiles import (
+    GOLDEN_COMBINATIONS,
+    PROFILE_DIR,
+    PROFILES,
+    RELEASES,
+    SUPPORTED_ODOO_VERSIONS,
+    GoldenPath,
+    ProfileCatalog,
+    check_compatibility,
+    get_golden_path,
+    get_release,
+)
+
+
+class TestReleaseFacts:
+    """Facts about the published images, not preferences."""
+
+    @pytest.mark.parametrize(
+        ("version", "distro", "python", "pip"),
+        [
+            ("15.0", "debian-bullseye", "3.9", "20.3.4"),
+            ("16.0", "debian-bullseye", "3.9", "20.3.4"),
+            ("17.0", "ubuntu-jammy", "3.10", "22.0.2"),
+            ("18.0", "ubuntu-noble", "3.12", "24.0"),
+            ("19.0", "ubuntu-noble", "3.12", "24.0"),
+        ],
+    )
+    def test_image_facts(self, version, distro, python, pip):
+        release = get_release(version)
+        assert release.base_distro == distro
+        assert release.python_version == python
+        assert release.pip_version == pip
+
+    @pytest.mark.parametrize("version", ["15.0", "16.0", "17.0"])
+    def test_older_images_lack_break_system_packages(self, version):
+        """pip < 23. The flag that broke the build in #152."""
+        assert get_release(version).supports_break_system_packages is False
+
+    @pytest.mark.parametrize("version", ["18.0", "19.0"])
+    def test_newer_images_have_break_system_packages(self, version):
+        assert get_release(version).supports_break_system_packages is True
+
+    @pytest.mark.parametrize("version", ["15.0", "16.0"])
+    def test_bullseye_images_lack_pipx(self, version):
+        """pipx is not packaged for Debian bullseye; the Dockerfile tolerates that."""
+        assert get_release(version).has_pipx is False
+
+    def test_three_distinct_bases_are_covered(self):
+        assert len({r.base_distro for r in RELEASES.values()}) == 3
+
+    def test_unsupported_version_names_the_supported_ones(self):
+        with pytest.raises(ValueError, match="19.0"):
+            get_release("13.0")
+
+
+class TestPostgresCompatibility:
+    @pytest.mark.parametrize("version", ["15.0", "16.0", "17.0", "18.0"])
+    def test_odoo_15_to_18_require_postgres_12(self, version):
+        assert get_release(version).postgres_minimum == 12
+
+    def test_odoo_19_requires_postgres_13(self):
+        """Odoo 19 raised the minimum from 12 to 13."""
+        assert get_release("19.0").postgres_minimum == 13
+
+    def test_the_old_hardcoded_pairing_is_now_rejected(self):
+        """Odoo 19 + PostgreSQL 12 was reachable in the wizard before #139."""
+        message = check_compatibility("19.0", "12")
+        assert message is not None
+        assert "13 or above" in message
+
+    @pytest.mark.parametrize("db", ["13", "14", "15", "16", "17"])
+    def test_odoo_19_accepts_13_and_above(self, db):
+        assert check_compatibility("19.0", db) is None
+
+    def test_odoo_18_accepts_postgres_12(self):
+        assert check_compatibility("18.0", "12") is None
+
+    def test_supported_list_excludes_versions_below_the_minimum(self):
+        assert "12" not in get_release("19.0").supported_postgres()
+        assert "12" in get_release("18.0").supported_postgres()
+
+    def test_a_non_numeric_version_is_not_supported(self):
+        assert get_release("18.0").supports_postgres("latest") is False
+
+
+class TestProfileCatalog:
+    def test_every_supported_version_has_both_editions(self):
+        for version in SUPPORTED_ODOO_VERSIONS:
+            major = version.split(".")[0]
+            assert f"odoo{major}-ce" in PROFILES
+            assert f"odoo{major}-ee" in PROFILES
+
+    def test_catalog_is_loaded_from_the_yaml_files(self):
+        """The YAML files are the source of truth for which profiles exist."""
+        on_disk = {p.stem for p in PROFILE_DIR.glob("*.yaml")}
+        assert on_disk == set(PROFILES)
+
+    @pytest.mark.parametrize("path", sorted(PROFILE_DIR.glob("*.yaml")), ids=lambda p: p.stem)
+    def test_every_profile_file_parses(self, path):
+        data = yaml.safe_load(path.read_text())
+        data.pop("golden", None)
+        assert GoldenPath.model_validate(data).name == path.stem
+
+    def test_profile_defaults_to_a_supported_postgres(self):
+        for profile in PROFILES.values():
+            assert check_compatibility(profile.odoo_version, profile.db_version) is None
+
+    def test_editions_map_to_the_right_suffix(self):
+        assert get_golden_path("odoo18-ce").edition == "Community"
+        assert get_golden_path("odoo18-ee").edition == "Enterprise"
+
+    def test_unknown_profile_lists_the_available_ones(self):
+        with pytest.raises(ValueError, match="odoo18-ce"):
+            get_golden_path("odoo99-ce")
+
+    def test_golden_combinations_are_marked(self):
+        for version, edition in GOLDEN_COMBINATIONS:
+            major = version.split(".")[0]
+            suffix = "ee" if edition == "Enterprise" else "ce"
+            assert get_golden_path(f"odoo{major}-{suffix}").is_golden is True
+
+    def test_non_golden_combinations_are_not_marked(self):
+        assert get_golden_path("odoo16-ee").is_golden is False
+
+    def test_catalog_rows_cover_every_profile(self):
+        assert len(ProfileCatalog().rows()) == len(PROFILES)
+
+
+class TestGoldenPathValidation:
+    def test_rejects_an_unsupported_odoo_version(self):
+        with pytest.raises(ValidationError):
+            GoldenPath(name="x", description="x", odoo_version="13.0")
+
+    def test_rejects_an_incompatible_postgres(self):
+        with pytest.raises(ValidationError, match="13 or above"):
+            GoldenPath(name="x", description="x", odoo_version="19.0", db_version="12")
+
+    def test_defaults_to_the_recommended_postgres(self):
+        assert GoldenPath(name="x", description="x", odoo_version="18.0").db_version == "16"
+
+    def test_rejects_an_unknown_edition(self):
+        with pytest.raises(ValidationError):
+            GoldenPath(name="x", description="x", odoo_version="18.0", edition="Ultimate")
+
+
+class TestProfileNotes:
+    def test_enterprise_warns_about_the_addons_directory(self):
+        notes = get_golden_path("odoo18-ee").notes()
+        assert any("enterprise" in n.lower() for n in notes)
+
+    def test_community_does_not_warn_about_enterprise(self):
+        notes = get_golden_path("odoo18-ce").notes()
+        assert not any("subscription" in n.lower() for n in notes)
+
+    def test_non_golden_says_it_is_best_effort(self):
+        assert any("best-effort" in n for n in get_golden_path("odoo16-ee").notes())
+
+    def test_golden_does_not_say_best_effort(self):
+        assert not any("best-effort" in n for n in get_golden_path("odoo18-ce").notes())
+
+    def test_odoo_19_on_old_postgres_warns_about_pgvector(self):
+        """Odoo 19's AI features need pgvector, which ships for PostgreSQL 15+."""
+        profile = GoldenPath(name="x", description="x", odoo_version="19.0", db_version="13")
+        assert any("pgvector" in n for n in profile.notes())
+
+    def test_odoo_19_on_current_postgres_does_not_warn(self):
+        assert not any("pgvector" in n for n in get_golden_path("odoo19-ce").notes())
+
+
+class TestRenderContext:
+    def test_context_carries_the_profile_values(self):
+        context = get_golden_path("odoo18-ce").to_context("demo", "pw")
+        assert context["odoo_version"] == "18.0"
+        assert context["db_version"] == "16"
+        assert context["odoo_image"] == "odoo:18.0"
+        assert context["admin_passwd"] == "pw"
+
+    def test_container_names_follow_the_project(self):
+        context = get_golden_path("odoo18-ce").to_context("demo", "pw")
+        assert context["odoo_container"] == "odoo-demo"
+        assert context["db_container"] == "db-demo"
+
+    @pytest.mark.parametrize("name", sorted(PROFILES))
+    def test_every_profile_renders_a_valid_compose(self, name):
+        """A profile that cannot render is not a golden path."""
+        from tests.test_templates import render
+
+        context = get_golden_path(name).to_context("demo", "pw")
+        context.setdefault("use_third_party_repos", False)
+        compose = yaml.safe_load(render("docker-compose.yaml.jinja", **context))
+        assert {"web", "db"} <= set(compose["services"])
+        assert compose["services"]["db"]["image"] == f"postgres:{get_golden_path(name).db_version}"
+
+    @pytest.mark.parametrize("name", sorted(PROFILES))
+    def test_every_profile_renders_the_right_dockerfile(self, name):
+        from tests.test_templates import render
+
+        profile = get_golden_path(name)
+        context = profile.to_context("demo", "pw")
+        context.setdefault("use_third_party_repos", False)
+        assert f"FROM odoo:{profile.odoo_version}" in render("Dockerfile.jinja", **context)

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -213,3 +213,26 @@ class TestRenderContext:
         context = profile.to_context("demo", "pw")
         context.setdefault("use_third_party_repos", False)
         assert f"FROM odoo:{profile.odoo_version}" in render("Dockerfile.jinja", **context)
+
+
+class TestProfilesArePackaged:
+    """The profiles must ship inside the installed package.
+
+    They live under templates/, which package-data covers, but nothing else
+    would notice if that stopped being true until `rkd profiles list` came back
+    empty for an installed user.
+    """
+
+    def test_the_profile_directory_is_inside_the_package(self):
+        from rocketdoo.core.models import profiles as module
+
+        package_root = __import__("rocketdoo").__path__[0]
+        assert str(PROFILE_DIR).startswith(package_root)
+        assert module.PROFILE_DIR.is_dir()
+
+    def test_ten_profiles_are_shipped(self):
+        assert len(list(PROFILE_DIR.glob("*.yaml"))) == 10
+
+    def test_the_readme_documents_the_policy(self):
+        readme = (PROFILE_DIR / "README.md").read_text()
+        assert "golden" in readme and "best effort" in readme


### PR DESCRIPTION
Cuarta épica del roadmap IDP (E4). Perfiles declarativos por versión de Odoo y
edición, con matriz de compatibilidad y modo no interactivo.

**644 tests** (desde 627). `rkd init` interactivo sigue funcionando igual; `--profile` es aditivo.

## El bug que motiva la épica

El wizard tenía **dos listas hardcodeadas sin relación entre sí**:

```python
odoo_versions = ["15.0", "16.0", "17.0", "18.0", "19.0"]   # línea 152
db_versions   = ["13", "14", "15", "16"]                    # línea 232
```

Nada las conectaba, así que se podía generar **Odoo 19 sobre PostgreSQL 12**, que Odoo no soporta. Ahora la lista de PostgreSQL se deriva de la versión de Odoo elegida:

```
📦 Select the PostgreSQL version for Odoo 19.0
   [Odoo 19.0 requires PostgreSQL 13 or above]
```

## Los datos son verificados, no asumidos

Los hechos por imagen los leí de las imágenes `odoo:` publicadas, no de memoria:

| Odoo | Base | Python | pip | PG mínimo | Recomendado |
|---|---|---|---|---|---|
| 15.0 | debian-bullseye | 3.9 | 20.3.4 | 12 | 14 |
| 16.0 | debian-bullseye | 3.9 | 20.3.4 | 12 | 14 |
| 17.0 | ubuntu-jammy | 3.10 | 22.0.2 | 12 | 15 |
| 18.0 | ubuntu-noble | 3.12 | 24.0 | 12 | 16 |
| 19.0 | ubuntu-noble | 3.12 | 24.0 | **13** | 16 |

Los mínimos de PostgreSQL salen de la documentación de instalación de Odoo: 15–18 piden 12.0 o superior; **19 subió a 13.0**.

## Lo nuevo

```bash
rkd profiles list              # la matriz completa
rkd profiles show odoo18-ce    # detalle de un perfil
rkd init --profile odoo18-ce   # crea el entorno sin preguntar nada
```

Diez perfiles en `templates/profiles/*.yaml` (Odoo 15–19 × CE/EE), que son la fuente de verdad. Los datos de la imagen no se declaran ahí porque describen la imagen publicada, no una decisión del perfil.

`generate_project()` se extrajo de `init_project()` para que el wizard y el perfil produzcan proyectos idénticos con las mismas elecciones.

## Política de soporte, documentada

| Nivel | Significado |
|---|---|
| **golden** | El CI la renderiza y valida en cada PR. `odoo15-ce`, `odoo18-ce`, `odoo19-ee` — cubren los tres sistemas base y las dos ediciones. |
| **best effort** | Dentro de los requisitos de Odoo, ofrecida por el wizard, pero no construida por CI. |

Nuevo job `golden-paths` en el CI: hace `rkd scaffold && rkd init --profile X`, valida con `docker compose config` y verifica que el `FROM odoo:` y el `postgres:` rendereados coincidan con el perfil.

## Un hueco encontrado en el camino Enterprise

`check_enterprise_folder()` respondía **OK con una carpeta `enterprise/` vacía** — que es exactamente lo que deja un `git clone` fallido por falta de credenciales. El proyecto parecía listo y Odoo arrancaba sin los addons.

`validate_enterprise_setup()` ahora distingue: falta la carpeta, está vacía, o no contiene ninguno de los módulos que Odoo Enterprise siempre trae.

## Otros

- `rkd init` ya no acepta `--odoo-version`/`--docker-compose`, que se ignoraban ([#157](https://github.com/HDM-soft/rocketdoo/issues/157)); `--profile` cubre el caso de uso real
- `scaffold` ya no copia `templates/profiles/` al proyecto del usuario
- Test que verifica que los perfiles viajen en el wheel — sin eso, `rkd profiles list` saldría vacío para un usuario instalado

## Cómo probarlo

```bash
pip install -e . -r requirements-dev.txt
pytest                                  # 644 pasan
rkd profiles list
mkdir /tmp/demo && cd /tmp/demo
rkd scaffold && rkd init --profile odoo18-ce
docker compose config
```

Política documentada en `rocketdoo/templates/profiles/README.md`.

Refs #139
