### PR TITLE
FIX: el build falla en Odoo 18 y 19 por EXTERNALLY-MANAGED

### DIFF
--- a/rocketdoo/templates/Dockerfile.jinja
+++ b/rocketdoo/templates/Dockerfile.jinja
@@ -10,16 +10,18 @@ COPY ./install_dependencies.sh /usr/lib/python3/dist-packages/odoo/
 
 USER root
 
-# Permite instalar con pip en la imagen base.
-# No usar --break-system-packages: llegó en pip 23 y las imágenes base viejas
-# no lo soportan (odoo:15.0/16.0 = Debian bullseye, pip 20.3; odoo:17.0 =
-# Ubuntu jammy, pip 22.0). Borrar EXTERNALLY-MANAGED sirve en todas: donde el
-# archivo no existe, el rm -f no falla.
-RUN rm -f /usr/lib/python*/EXTERNALLY-MANAGED
-
 # pipx no está en los repos de Debian bullseye (odoo:15.0/16.0). Es una
 # conveniencia para trabajar dentro del contenedor, no un requisito del build,
 # así que su ausencia no debe abortar la imagen.
+#
+# El rm de EXTERNALLY-MANAGED va acá, en la misma capa y DESPUÉS de los apt
+# install, no en una capa previa: python3-dev arrastra el paquete python3.N,
+# que vuelve a colocar el archivo. Borrarlo antes no sirve de nada en
+# odoo:18.0/19.0 (Ubuntu noble), donde el marcador sí existe.
+#
+# No usar --break-system-packages para lo mismo: llegó en pip 23 y las imágenes
+# viejas no lo soportan (odoo:15.0/16.0 = bullseye, pip 20.3; odoo:17.0 =
+# jammy, pip 22.0). Donde el archivo no existe, el rm -f no falla.
 RUN apt update && \
     apt install -y libssl-dev swig python3-dev gcc && \
     apt install -y python3-m2crypto && \
@@ -27,6 +29,7 @@ RUN apt update && \
     { apt install -y pipx || echo "pipx no disponible en esta imagen base, se omite"; } && \
     apt clean && \
     rm -rf /var/lib/apt/lists/* && \
+    rm -f /usr/lib/python*/EXTERNALLY-MANAGED && \
     python3 -m pip install debugpy gitman
 
 #RUN mkdir -p /root/.ssh

--- a/tests/snapshots/Dockerfile.jinja.txt
+++ b/tests/snapshots/Dockerfile.jinja.txt
@@ -8,16 +8,18 @@ COPY ./install_dependencies.sh /usr/lib/python3/dist-packages/odoo/
 
 USER root
 
-# Permite instalar con pip en la imagen base.
-# No usar --break-system-packages: llegó en pip 23 y las imágenes base viejas
-# no lo soportan (odoo:15.0/16.0 = Debian bullseye, pip 20.3; odoo:17.0 =
-# Ubuntu jammy, pip 22.0). Borrar EXTERNALLY-MANAGED sirve en todas: donde el
-# archivo no existe, el rm -f no falla.
-RUN rm -f /usr/lib/python*/EXTERNALLY-MANAGED
-
 # pipx no está en los repos de Debian bullseye (odoo:15.0/16.0). Es una
 # conveniencia para trabajar dentro del contenedor, no un requisito del build,
 # así que su ausencia no debe abortar la imagen.
+#
+# El rm de EXTERNALLY-MANAGED va acá, en la misma capa y DESPUÉS de los apt
+# install, no en una capa previa: python3-dev arrastra el paquete python3.N,
+# que vuelve a colocar el archivo. Borrarlo antes no sirve de nada en
+# odoo:18.0/19.0 (Ubuntu noble), donde el marcador sí existe.
+#
+# No usar --break-system-packages para lo mismo: llegó en pip 23 y las imágenes
+# viejas no lo soportan (odoo:15.0/16.0 = bullseye, pip 20.3; odoo:17.0 =
+# jammy, pip 22.0). Donde el archivo no existe, el rm -f no falla.
 RUN apt update && \
     apt install -y libssl-dev swig python3-dev gcc && \
     apt install -y python3-m2crypto && \
@@ -25,6 +27,7 @@ RUN apt update && \
     { apt install -y pipx || echo "pipx no disponible en esta imagen base, se omite"; } && \
     apt clean && \
     rm -rf /var/lib/apt/lists/* && \
+    rm -f /usr/lib/python*/EXTERNALLY-MANAGED && \
     python3 -m pip install debugpy gitman
 
 #RUN mkdir -p /root/.ssh

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -245,33 +245,42 @@ class TestDockerfilePipInstall:
     def dockerfile(self):
         return render("Dockerfile.jinja", **PROJECT_CONTEXT)
 
-    def test_does_not_use_break_system_packages(self, dockerfile):
+    @pytest.fixture
+    def instructions(self, dockerfile):
+        """The Dockerfile without comments — what actually runs.
+
+        The comments deliberately mention --break-system-packages to explain
+        why it is not used, so a plain substring check would fail on them.
+        """
+        return "\n".join(line for line in dockerfile.splitlines() if not line.lstrip().startswith("#"))
+
+    def test_does_not_use_break_system_packages(self, instructions):
         """pip 20.3 (bullseye) and 22.0 (jammy) reject the flag outright."""
-        assert "--break-system-packages" not in dockerfile
+        assert "--break-system-packages" not in instructions
 
-    def test_removes_the_externally_managed_marker(self, dockerfile):
-        assert "rm -f /usr/lib/python*/EXTERNALLY-MANAGED" in dockerfile
+    def test_removes_the_externally_managed_marker(self, instructions):
+        assert "rm -f /usr/lib/python*/EXTERNALLY-MANAGED" in instructions
 
-    def test_the_marker_is_removed_after_apt_and_before_pip(self, dockerfile):
+    def test_the_marker_is_removed_after_apt_and_before_pip(self, instructions):
         """Order is the whole bug: python3-dev reinstates the marker.
 
         A removal in an earlier layer is undone by the apt install, so pip then
         fails with externally-managed-environment on Ubuntu noble.
         """
-        removal = dockerfile.index("rm -f /usr/lib/python*/EXTERNALLY-MANAGED")
-        apt_install = dockerfile.rindex("apt install -y python3-m2crypto")
-        pip_install = dockerfile.index("python3 -m pip install")
+        removal = instructions.index("rm -f /usr/lib/python*/EXTERNALLY-MANAGED")
+        apt_install = instructions.rindex("apt install -y python3-m2crypto")
+        pip_install = instructions.index("python3 -m pip install")
 
         assert apt_install < removal < pip_install, (
             "EXTERNALLY-MANAGED must be removed after the apt installs (python3-dev puts it back) and before pip runs"
         )
 
-    def test_the_removal_shares_a_layer_with_pip(self, dockerfile):
+    def test_the_removal_shares_a_layer_with_pip(self, instructions):
         """Same RUN: a separate layer would be undone by any later apt."""
-        run_blocks = dockerfile.split("\nRUN ")
+        run_blocks = instructions.split("\nRUN ")
         pip_block = next(b for b in run_blocks if "python3 -m pip install" in b)
         assert "EXTERNALLY-MANAGED" in pip_block
 
-    def test_pipx_failure_does_not_abort_the_build(self, dockerfile):
+    def test_pipx_failure_does_not_abort_the_build(self, instructions):
         """pipx is not packaged for bullseye (odoo:15.0/16.0)."""
-        assert "|| echo" in dockerfile
+        assert "|| echo" in instructions

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -230,3 +230,48 @@ class TestGitignoreTemplate:
         rendered = template_content()
         entries = {ln.strip() for ln in rendered.splitlines() if ln.strip() and not ln.startswith("#")}
         assert {pat for pat, _ in SENSITIVE_ENTRIES} <= entries
+
+
+class TestDockerfilePipInstall:
+    """The PEP 668 marker handling, which broke the build twice.
+
+    #152: `--break-system-packages` was used, which pip 20/22 (odoo:15-17) does
+    not accept. #163: the marker was removed in its own layer, before the apt
+    install that reinstates it on odoo:18/19 — so the removal had no effect
+    where it was actually needed.
+    """
+
+    @pytest.fixture
+    def dockerfile(self):
+        return render("Dockerfile.jinja", **PROJECT_CONTEXT)
+
+    def test_does_not_use_break_system_packages(self, dockerfile):
+        """pip 20.3 (bullseye) and 22.0 (jammy) reject the flag outright."""
+        assert "--break-system-packages" not in dockerfile
+
+    def test_removes_the_externally_managed_marker(self, dockerfile):
+        assert "rm -f /usr/lib/python*/EXTERNALLY-MANAGED" in dockerfile
+
+    def test_the_marker_is_removed_after_apt_and_before_pip(self, dockerfile):
+        """Order is the whole bug: python3-dev reinstates the marker.
+
+        A removal in an earlier layer is undone by the apt install, so pip then
+        fails with externally-managed-environment on Ubuntu noble.
+        """
+        removal = dockerfile.index("rm -f /usr/lib/python*/EXTERNALLY-MANAGED")
+        apt_install = dockerfile.rindex("apt install -y python3-m2crypto")
+        pip_install = dockerfile.index("python3 -m pip install")
+
+        assert apt_install < removal < pip_install, (
+            "EXTERNALLY-MANAGED must be removed after the apt installs (python3-dev puts it back) and before pip runs"
+        )
+
+    def test_the_removal_shares_a_layer_with_pip(self, dockerfile):
+        """Same RUN: a separate layer would be undone by any later apt."""
+        run_blocks = dockerfile.split("\nRUN ")
+        pip_block = next(b for b in run_blocks if "python3 -m pip install" in b)
+        assert "EXTERNALLY-MANAGED" in pip_block
+
+    def test_pipx_failure_does_not_abort_the_build(self, dockerfile):
+        """pipx is not packaged for bullseye (odoo:15.0/16.0)."""
+        assert "|| echo" in dockerfile


### PR DESCRIPTION
Corrige #163, que bloquea la publicación de 3.2.0.

## Causa

El Dockerfile borraba el marcador PEP 668 **en una capa propia, antes de los `apt install`**:

```dockerfile
RUN rm -f /usr/lib/python*/EXTERNALLY-MANAGED     # capa 1

RUN apt update && \
    apt install -y ... python3-dev ... && \      # <- lo reinstala
    python3 -m pip install debugpy gitman         # <- falla acá
```

`python3-dev` arrastra el paquete `python3.N`, que **vuelve a colocar** el archivo. Verificado dentro de la imagen:

```
tras el rm:                     BORRADO
tras apt install python3-dev:   /usr/lib/python3.12/EXTERNALLY-MANAGED
pip install:                    FALLA
```

En Odoo 15/16/17 el marcador no existe en la imagen base, así que el `rm` es un no-op y nada lo restaura. Por eso #152 no lo detectó: se validó contra las tres versiones donde el archivo no existe.

## Fix

Mover el `rm` a la misma capa que el `pip install`, después de los `apt install`.

## Verificación

Construí **las cinco imágenes** localmente. Las cinco compilan y `debugpy` y `gitman` importan en todas:

| Odoo | Build | Deps |
|---|---|---|
| 15.0 | ✓ | ✓ |
| 16.0 | ✓ | ✓ |
| 17.0 | ✓ | ✓ |
| 18.0 | ✓ | ✓ |
| 19.0 | ✓ | ✓ |

## Tests

`TestDockerfilePipInstall` fija el orden como invariante: el `rm` va después de los `apt install`, antes del `pip install`, y en la misma capa. Más el guard de que no reaparezca `--break-system-packages`, que es cómo se rompió en #152.

Detectado por la matriz de build de #136 en el primer PR de release que la ejecuta (#162) — que es exactamente para lo que se agregó.

Refs #163