### PR TITLE
FIX: la API de la GUI aceptaba peticiones de cualquier origen

### DIFF
--- a/rocketdoo/gui/server.py
+++ b/rocketdoo/gui/server.py
@@ -7,8 +7,28 @@ from fastapi.responses import FileResponse, JSONResponse
 
 STATIC_DIR = Path(__file__).parent / "static"
 
+DEFAULT_PORT = 8070
+_LOOPBACK_HOSTS = ("127.0.0.1", "localhost", "::1", "0.0.0.0")
 
-def create_app() -> FastAPI:
+
+def local_origins(host: str = "127.0.0.1", port: int = DEFAULT_PORT) -> list[str]:
+    """Browser origins allowed to call this API.
+
+    The SPA is served from this same app, so its own requests are same-origin
+    and need no CORS at all. The header only ever matters for a *different*
+    page calling in — which is exactly what must not be allowed: these
+    endpoints drive Docker and browse the filesystem, and binding to localhost
+    is no protection, since the request comes from the user's own browser.
+    """
+    origins = [f"http://localhost:{port}", f"http://127.0.0.1:{port}"]
+    if host not in _LOOPBACK_HOSTS:
+        # Explicitly bound elsewhere (e.g. --host 192.168.1.10): allow that too,
+        # otherwise the page the user actually opens cannot call its own API.
+        origins.append(f"http://{host}:{port}")
+    return origins
+
+
+def create_app(host: str = "127.0.0.1", port: int = DEFAULT_PORT) -> FastAPI:
     app = FastAPI(
         title="Rocketdoo GUI",
         version="3.0.0",
@@ -16,9 +36,12 @@ def create_app() -> FastAPI:
         redoc_url=None,
     )
 
+    # Not allow_origins=["*"]: with allow_credentials=True Starlette echoes the
+    # caller's Origin back, so any site the user visited while `rkd gui` was
+    # running could read /api/workspace and POST /api/docker/down.
     app.add_middleware(
         CORSMiddleware,
-        allow_origins=["*"],
+        allow_origins=local_origins(host, port),
         allow_credentials=True,
         allow_methods=["*"],
         allow_headers=["*"],

--- a/rocketdoo/gui_cli.py
+++ b/rocketdoo/gui_cli.py
@@ -57,5 +57,7 @@ def gui_command(port, host, auto_open, cwd):
 
         threading.Thread(target=_open, daemon=True).start()
 
-    app = create_app()
+    # host/port reach the app so CORS can allow exactly the origin the user
+    # will open, and nothing else.
+    app = create_app(host=host, port=port)
     uvicorn.run(app, host=host, port=port, log_level="error")

--- a/tests/test_gui_api.py
+++ b/tests/test_gui_api.py
@@ -175,3 +175,86 @@ class TestInstancesRoundTrip:
         body = response.json()
         assert body["ok"] is True
         assert "vps.host" in body["incomplete"]["stage"]
+
+
+class TestCORSPolicy:
+    """The GUI API must only be callable from the page it serves.
+
+    These endpoints drive Docker and browse the filesystem. Binding to
+    127.0.0.1 is no protection on its own: the request comes from the user's
+    own browser, so any site they visit while `rkd gui` runs is already on
+    localhost as far as the server is concerned. With allow_origins=["*"] and
+    allow_credentials=True, Starlette echoes the caller's Origin back and the
+    browser lets that site read the response.
+    """
+
+    EVIL = "https://malicious.example"
+
+    def test_a_foreign_origin_cannot_read_responses(self, client):
+        response = client.get("/api/workspace", headers={"Origin": self.EVIL})
+        allowed = response.headers.get("access-control-allow-origin")
+        assert allowed != self.EVIL
+        assert allowed != "*"
+
+    def test_a_foreign_origin_preflight_is_rejected(self, client):
+        response = client.options(
+            "/api/docker/down",
+            headers={
+                "Origin": self.EVIL,
+                "Access-Control-Request-Method": "POST",
+                "Access-Control-Request-Headers": "content-type",
+            },
+        )
+        assert response.status_code >= 400
+
+    @pytest.mark.parametrize("origin", ["http://localhost:8070", "http://127.0.0.1:8070"])
+    def test_the_gui_own_origins_are_allowed(self, client, origin):
+        response = client.get("/api/workspace", headers={"Origin": origin})
+        assert response.headers.get("access-control-allow-origin") == origin
+
+    def test_the_wildcard_is_never_used(self, client):
+        """allow_origins=["*"] is what made this exploitable."""
+        response = client.get("/api/workspace", headers={"Origin": "http://localhost:8070"})
+        assert response.headers.get("access-control-allow-origin") != "*"
+
+    def test_the_spa_is_still_served(self, client):
+        """Same-origin requests need no CORS; the page itself must still load."""
+        assert client.get("/").status_code == 200
+
+
+class TestLocalOrigins:
+    def test_defaults_to_both_loopback_names(self):
+        from rocketdoo.gui.server import local_origins
+
+        assert local_origins() == ["http://localhost:8070", "http://127.0.0.1:8070"]
+
+    def test_follows_a_custom_port(self):
+        """`rkd gui --port 9090` must allow the port the user actually opens."""
+        from rocketdoo.gui.server import local_origins
+
+        assert local_origins(port=9090) == ["http://localhost:9090", "http://127.0.0.1:9090"]
+
+    def test_an_explicit_external_host_is_added(self):
+        from rocketdoo.gui.server import local_origins
+
+        assert "http://192.168.1.10:8070" in local_origins("192.168.1.10", 8070)
+
+    @pytest.mark.parametrize("host", ["127.0.0.1", "localhost", "0.0.0.0", "::1"])
+    def test_loopback_hosts_add_nothing_extra(self, host):
+        from rocketdoo.gui.server import local_origins
+
+        assert len(local_origins(host)) == 2
+
+    def test_no_origin_is_a_wildcard(self):
+        from rocketdoo.gui.server import local_origins
+
+        assert "*" not in local_origins("192.168.1.10", 9090)
+
+
+def test_the_app_honours_the_port_it_was_created_with():
+    """`rkd gui --port N` passes N through, so CORS matches the real URL."""
+    from rocketdoo.gui.server import create_app
+
+    client = fastapi_testclient.TestClient(create_app(port=9090))
+    response = client.get("/api/workspace", headers={"Origin": "http://localhost:9090"})
+    assert response.headers.get("access-control-allow-origin") == "http://localhost:9090"


### PR DESCRIPTION
Cubre el punto **(b)** de #142. Entra en 3.2.0 por ser acotado y de riesgo bajo.

## El problema

`gui/server.py` usaba `allow_origins=["*"]` con `allow_credentials=True`. En esa combinación Starlette **no puede** responder `*`, así que devuelve el `Origin` de quien llama — habilitando a ese sitio a leer la respuesta.

Verificado antes del fix:

```
GET /api/workspace  con  Origin: https://sitio-malicioso.example
  status                      : 200
  access-control-allow-origin : https://sitio-malicioso.example
  el navegador deja leer esto : SÍ
  cuerpo expuesto             : {'path': '/home/...'}

Preflight POST /api/docker/down desde el mismo origen
  status       : 200  (permitido)
```

Cualquier página que el usuario visitara mientras corría `rkd gui` podía listar su filesystem (`/api/workspace`, `/api/workspace/browse`), leer la config del proyecto y ejecutar `POST /api/docker/down` o `/api/instances/deploy`.

**Bindear a `127.0.0.1` no protege**: la petición la hace el navegador del propio usuario, que ya está en localhost.

## El fix

Los orígenes permitidos pasan a ser los de la propia GUI, derivados del host y puerto con que se levanta, así `--port` y `--host` siguen funcionando:

```
local_origins()                      -> ['http://localhost:8070', 'http://127.0.0.1:8070']
local_origins(port=9090)             -> ['http://localhost:9090', 'http://127.0.0.1:9090']
local_origins('192.168.1.10', 8070)  -> [... , 'http://192.168.1.10:8070']
```

El SPA se sirve desde la misma app, así que sus llamadas son same-origin y no dependen de CORS.

## Después del fix

```
GET /api/workspace  con  Origin: https://sitio-malicioso.example
  allow-origin                : None
  el navegador deja leer esto : NO — bloqueado

Preflight POST /api/docker/down
  status : 400  (rechazado)

La GUI legítima (http://localhost:8070)
  allow-origin : http://localhost:8070
  status       : 200
```

## Sobre el resto de #142

- **(c) los 4 endpoints rotos** — ya resuelto en #136, arreglándolos de verdad en lugar de devolver 501 como pedía el criterio
- **(a) password por argv de `sshpass -p`** — pendiente: toca ambos deployers y no puedo verificarlo end-to-end sin un VPS real. Va a 3.2.1

Refs #142