### PR TITLE
FIX: rkd pack — completa el release candidate 3.2.0

### DIFF
--- a/rocketdoo/pack_environment.py
+++ b/rocketdoo/pack_environment.py
@@ -315,6 +315,11 @@ def pack_environment(no_db, output, db_name):
     backup_dir = project_dir / "rkd_backups"
     db_backup_path = None
     fs_backup_path = None
+    # Initialised here, not inside the `if not no_db` block below: with
+    # --no-db, or when the instance has no databases yet, none of the
+    # branches that assign it run, and the manifest at the end reads it
+    # anyway (UnboundLocalError).
+    filestore_base = None
 
     if not no_db:
         db_container = _get_db_container(compose_data) if compose_data else None

--- a/tests/test_pack_environment.py
+++ b/tests/test_pack_environment.py
@@ -1,0 +1,140 @@
+"""Tests for pack_environment.py.
+
+`rkd pack` failed on every invocation with UnboundLocalError: `filestore_base`
+was only assigned inside one deep branch, but the manifest at the end reads it
+unconditionally. Two paths reached that read without passing through the
+assignment — `--no-db`, and an instance with no databases yet — which is both
+of the ways the command is normally used before there is data to share.
+
+The module had no tests at all; these cover the manifest paths. Its extraction
+to core/pack.py is #143.
+"""
+
+import json
+import zipfile
+
+import pytest
+
+from rocketdoo.core.gitignore_manager import SENSITIVE_ENTRIES
+from rocketdoo.init_project import init_from_profile
+from rocketdoo.scaffold import scaffold_project
+
+
+@pytest.fixture
+def packable_project(project_dir):
+    """A generated project, without containers running."""
+    scaffold_project()
+    init_from_profile("odoo18-ce", project_name="packdemo")
+    return project_dir
+
+
+def _zip_for(project_dir):
+    """The ZIP `pack` writes, which lands beside the project, not inside it."""
+    candidates = sorted(project_dir.parent.glob("*_rkd_shared_*.zip"))
+    assert candidates, "pack produced no ZIP"
+    return candidates[-1]
+
+
+class TestPackWithoutDatabase:
+    def test_no_db_completes(self, packable_project):
+        """The path that raised UnboundLocalError before #166."""
+        from click.testing import CliRunner
+
+        from rocketdoo.cli import main
+
+        result = CliRunner().invoke(main, ["pack", "--no-db"])
+        assert result.exit_code == 0, result.output
+        assert result.exception is None or isinstance(result.exception, SystemExit)
+
+    def test_no_db_writes_a_zip(self, packable_project):
+        from click.testing import CliRunner
+
+        from rocketdoo.cli import main
+
+        CliRunner().invoke(main, ["pack", "--no-db"])
+        assert _zip_for(packable_project).exists()
+
+    def test_the_manifest_records_no_backup(self, packable_project):
+        from click.testing import CliRunner
+
+        from rocketdoo.cli import main
+
+        CliRunner().invoke(main, ["pack", "--no-db"])
+        with zipfile.ZipFile(_zip_for(packable_project)) as zf:
+            manifest = json.loads(zf.read("rkd-shared.json"))
+
+        assert manifest["has_db_backup"] is False
+        assert manifest["filestore_base"] is None
+
+    def test_the_zip_carries_the_project_files(self, packable_project):
+        from click.testing import CliRunner
+
+        from rocketdoo.cli import main
+
+        CliRunner().invoke(main, ["pack", "--no-db"])
+        with zipfile.ZipFile(_zip_for(packable_project)) as zf:
+            names = zf.namelist()
+
+        assert any(n.endswith("Dockerfile") for n in names)
+        assert any(n.endswith("docker-compose.yaml") for n in names)
+        assert "rkd-shared.json" in names
+
+    def test_no_ssh_key_is_ever_packed(self, packable_project):
+        """The whole point of the sanitise step: keys must not travel."""
+        from click.testing import CliRunner
+
+        from rocketdoo.cli import main
+
+        ssh_dir = packable_project / ".ssh"
+        ssh_dir.mkdir()
+        (ssh_dir / "id_rsa").write_text("PRIVATE KEY MATERIAL")
+
+        CliRunner().invoke(main, ["pack", "--no-db"])
+        with zipfile.ZipFile(_zip_for(packable_project)) as zf:
+            names = zf.namelist()
+            blob = b"".join(zf.read(n) for n in names if not n.endswith("/"))
+
+        assert not any("/.ssh/" in n or n.startswith(".ssh/") for n in names)
+        assert b"PRIVATE KEY MATERIAL" not in blob
+
+
+class TestPackManifest:
+    def test_the_manifest_describes_the_project(self, packable_project):
+        from click.testing import CliRunner
+
+        from rocketdoo.cli import main
+
+        CliRunner().invoke(main, ["pack", "--no-db"])
+        with zipfile.ZipFile(_zip_for(packable_project)) as zf:
+            manifest = json.loads(zf.read("rkd-shared.json"))
+
+        assert manifest["odoo_version"] == "18.0"
+        assert "filestore_base" in manifest
+        assert "has_db_backup" in manifest
+
+    def test_the_manifest_is_json_serialisable_end_to_end(self, packable_project):
+        """`rkd unpack` parses this; a non-serialisable value breaks the receiver."""
+        from click.testing import CliRunner
+
+        from rocketdoo.cli import main
+
+        CliRunner().invoke(main, ["pack", "--no-db"])
+        with zipfile.ZipFile(_zip_for(packable_project)) as zf:
+            json.loads(zf.read("rkd-shared.json"))
+
+
+class TestPackedProjectKeepsSecretsOut:
+    def test_the_gitignore_travels(self, packable_project):
+        """The receiver must not commit the secrets either."""
+        from click.testing import CliRunner
+
+        from rocketdoo.cli import main
+
+        CliRunner().invoke(main, ["pack", "--no-db"])
+        with zipfile.ZipFile(_zip_for(packable_project)) as zf:
+            names = [n for n in zf.namelist() if n.endswith(".gitignore")]
+            assert names
+            content = zf.read(names[0]).decode()
+
+        entries = {ln.strip() for ln in content.splitlines() if ln.strip() and not ln.startswith("#")}
+        assert {pat for pat, _ in SENSITIVE_ENTRIES} <= entries


### PR DESCRIPTION
Arrastra a `test/v3` el fix de #166, detectado en el QA del RC anterior (#162).

Sin bump: 3.2.0 todavía no se publicó, así que el fix entra en la misma versión.

## Qué agrega

**#167** — `rkd pack` fallaba con `UnboundLocalError: filestore_base` en sus dos modos (`--no-db`, y sin bases de datos creadas). Bug preexistente en 3.1.8, no una regresión de estas épicas.

Más ocho tests para `pack_environment.py`, que no tenía ninguno. Verifiqué que los ocho fallan sin el fix.

## Estado del QA sobre el RC anterior

Todo lo demás ya pasó el ciclo completo con el paquete instalado desde `test/v3`:

| | |
|---|---|
| `profiles list` / `show` | matriz correcta |
| `scaffold` + `init --profile odoo18-ce` | no interactivo, versiones correctas |
| **`up -d`** | **build de Odoo 18 OK** (lo que arreglaba #163) |
| Odoo real | 18.0-20260810 sirviendo; `debugpy` y `gitman` importan |
| `status`/`logs`/`stop`/`restart`/`down` | limpio |
| `mail on/status/off` | ciclo completo, Mailpit UI HTTP 200 |
| `traefik status/off/guide` | correcto |
| `deploy list-modules` | `tests/` ya no se lista como módulo |
| `gui` | 8 endpoints 200; CORS bloquea origen ajeno, respeta `--port` |
| Instancias | round-trip GUI → GUI → CLI sin `KeyError: 'vps'` |

Falta re-verificar `pack` sobre la rama, que es lo que este PR habilita.

Refs #166